### PR TITLE
Feat/editor model visibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [0.0.18](https://github.com/ajatdarojat45/frontend-v2/compare/v0.0.17...v0.0.18) (2025-10-23)
+
 ### [0.0.17](https://github.com/ajatdarojat45/frontend-v2/compare/v0.0.16...v0.0.17) (2025-10-23)
 
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [0.0.19](https://github.com/ajatdarojat45/frontend-v2/compare/v0.0.18...v0.0.19) (2025-10-23)
+
+### Features
+
+- create new material components ([79205fc](https://github.com/ajatdarojat45/frontend-v2/commit/79205fc9fd58e3fd9a0a6bed2c60c95240f75b18))
+- model view option ([bbd10af](https://github.com/ajatdarojat45/frontend-v2/commit/bbd10af932caf0b52de923be8e870292169ffb02))
+- surface visibility toggle ([eb75104](https://github.com/ajatdarojat45/frontend-v2/commit/eb7510432bd1d808ec0905c23eaddc5c29cda6a9))
+
 ### [0.0.18](https://github.com/ajatdarojat45/frontend-v2/compare/v0.0.17...v0.0.18) (2025-10-23)
 
 ### [0.0.17](https://github.com/ajatdarojat45/frontend-v2/compare/v0.0.16...v0.0.17) (2025-10-23)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,27 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [0.0.17](https://github.com/ajatdarojat45/frontend-v2/compare/v0.0.16...v0.0.17) (2025-10-23)
+
+### Features
+
+- add lazy loading for simulation results and enhance result parameters selector for improved data handling ([6e2be43](https://github.com/ajatdarojat45/frontend-v2/commit/6e2be43f519856d5d3bcb6023cc42c942f661a1b))
+- add modelId to compare results and update related components ([9d747df](https://github.com/ajatdarojat45/frontend-v2/commit/9d747dfcf8b2377fa8545abfa8e98b95b466b626))
+- enhance CompareResult and CompareResultItem components with improved result handling and simulation selection ([0b68b31](https://github.com/ajatdarojat45/frontend-v2/commit/0b68b312dcca36faa90059374d13abd2a87b6709))
+- enhance EditorNav with simulation result query and conditional rendering ([70ce600](https://github.com/ajatdarojat45/frontend-v2/commit/70ce6006ef2106cb068b51503439ad9fc223dcb4))
+- implement ChooseModel component for selecting models in comparison results ([e2a5d58](https://github.com/ajatdarojat45/frontend-v2/commit/e2a5d58e0ee58d1ec1ffd124d229eb70afc300b4))
+- implement CompareResult and CompareResultItem components for managing and displaying comparison results ([75c3c8a](https://github.com/ajatdarojat45/frontend-v2/commit/75c3c8a589b08427a583dd24f3504d930e0c6629))
+- refactor CompareResult and CompareResultItem components to use centralized color constants and improve color handling in ImpulseResponsePlayer ([653cf55](https://github.com/ajatdarojat45/frontend-v2/commit/653cf5503cbb5bf1eb16c4e8f6f977672178e2c5))
+- refactor simulation result handling to use selectors for improved state management and enhance component integration ([7c9cadb](https://github.com/ajatdarojat45/frontend-v2/commit/7c9cadb9196e4395716fc4333d834cba5fa30d38))
+- update CompareResult and CompareResultItem components to use isCurrent prop for improved simulation handling and UI interaction ([146ee15](https://github.com/ajatdarojat45/frontend-v2/commit/146ee154c795fb6e0717c4692129150bb53804a6))
+
+### Bug Fixes
+
+- always make text orient towards user ([387b216](https://github.com/ajatdarojat45/frontend-v2/commit/387b2167764db53e77a63ced1be47d955b38ad70))
+- change run simulation polling rate to 1 seconds ([81b94e1](https://github.com/ajatdarojat45/frontend-v2/commit/81b94e1e5ec4e11915d48fd5defb80c52c63e71d))
+- Results tab not showing up once run simulation completed ([8cd2b74](https://github.com/ajatdarojat45/frontend-v2/commit/8cd2b7441abcc78ec3d98152b3faff6a3ea7d2fc))
+- validation run simulation button when something is not valid ([6aa22b0](https://github.com/ajatdarojat45/frontend-v2/commit/6aa22b0024a9367c1937d4e91647a4b449b2f3d0))
+
 ### [0.0.16](https://github.com/ajatdarojat45/frontend-v2/compare/v0.0.15...v0.0.16) (2025-10-20)
 
 ### Features

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "app",
-  "version": "0.0.16",
+  "version": "0.0.17",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "app",
-      "version": "0.0.16",
+      "version": "0.0.17",
       "dependencies": {
         "@hookform/resolvers": "^5.2.2",
         "@monaco-editor/react": "^4.7.0",
@@ -52,6 +52,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.36.0",
+        "@tailwindcss/vite": "^4.1.13",
         "@types/node": "^24.5.2",
         "@types/react": "^19.1.13",
         "@types/react-dom": "^19.1.9",
@@ -66,6 +67,7 @@
         "lint-staged": "^16.2.3",
         "prettier": "^3.6.2",
         "standard-version": "^9.5.0",
+        "tailwindcss": "^4.1.13",
         "tw-animate-css": "^1.4.0",
         "typescript": "~5.8.3",
         "typescript-eslint": "^8.44.0",
@@ -376,6 +378,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -392,6 +395,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -408,6 +412,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -424,6 +429,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -440,6 +446,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -456,6 +463,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -472,6 +480,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -488,6 +497,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -504,6 +514,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -520,6 +531,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -536,6 +548,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -552,6 +565,7 @@
       "cpu": [
         "loong64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -568,6 +582,7 @@
       "cpu": [
         "mips64el"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -584,6 +599,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -600,6 +616,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -616,6 +633,7 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -632,6 +650,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -648,6 +667,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -664,6 +684,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -680,6 +701,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -696,6 +718,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -712,6 +735,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -728,6 +752,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -744,6 +769,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -760,6 +786,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -776,6 +803,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1055,6 +1083,7 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz",
       "integrity": "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "minipass": "^7.0.4"
@@ -1067,6 +1096,7 @@
       "version": "0.3.13",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
       "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.0",
@@ -1077,6 +1107,7 @@
       "version": "2.3.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
       "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/gen-mapping": "^0.3.5",
@@ -1087,6 +1118,7 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
       "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.0.0"
@@ -1096,12 +1128,14 @@
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.31",
       "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
       "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
@@ -2192,6 +2226,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2205,6 +2240,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2218,6 +2254,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2231,6 +2268,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2244,6 +2282,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2257,6 +2296,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2270,6 +2310,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2283,6 +2324,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2296,6 +2338,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2309,6 +2352,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2322,6 +2366,7 @@
       "cpu": [
         "loong64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2335,6 +2380,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2348,6 +2394,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2361,6 +2408,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2374,6 +2422,7 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2387,6 +2436,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2400,6 +2450,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2413,6 +2464,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2426,6 +2478,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2439,6 +2492,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2452,6 +2506,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2465,6 +2520,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2543,6 +2599,7 @@
       "version": "4.1.13",
       "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.1.13.tgz",
       "integrity": "sha512-eq3ouolC1oEFOAvOMOBAmfCIqZBJuvWvvYWh5h5iOYfe1HFC6+GZ6EIL0JdM3/niGRJmnrOc+8gl9/HGUaaptw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/remapping": "^2.3.4",
@@ -2558,6 +2615,7 @@
       "version": "4.1.13",
       "resolved": "https://registry.npmjs.org/@tailwindcss/oxide/-/oxide-4.1.13.tgz",
       "integrity": "sha512-CPgsM1IpGRa880sMbYmG1s4xhAy3xEt1QULgTJGQmZUeNgXFR7s1YxYygmJyBGtou4SyEosGAGEeYqY7R53bIA==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -2589,6 +2647,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2605,6 +2664,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2621,6 +2681,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2637,6 +2698,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2653,6 +2715,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2669,6 +2732,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2685,6 +2749,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2701,6 +2766,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2717,6 +2783,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2741,6 +2808,7 @@
       "cpu": [
         "wasm32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -2762,6 +2830,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2778,6 +2847,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2791,6 +2861,7 @@
       "version": "4.1.13",
       "resolved": "https://registry.npmjs.org/@tailwindcss/vite/-/vite-4.1.13.tgz",
       "integrity": "sha512-0PmqLQ010N58SbMTJ7BVJ4I2xopiQn/5i6nlb4JmxzQf8zcS5+m2Cv6tqh+sfDwtIdjoEnOvwsGQ1hkUi8QEHQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@tailwindcss/node": "4.1.13",
@@ -2862,6 +2933,7 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/json-schema": {
@@ -2891,7 +2963,7 @@
       "version": "24.5.2",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-24.5.2.tgz",
       "integrity": "sha512-FYxk1I7wPv3K2XBaoyH2cTnocQEu8AOZ60hPbsyukMPLv5/5qr7V1i8PLHdl6Zf87I+xZXFvPCXYjiTFq+YSDQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.12.0"
@@ -3700,6 +3772,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
       "integrity": "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==",
+      "dev": true,
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=18"
@@ -4343,6 +4416,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.1.tgz",
       "integrity": "sha512-ecqj/sy1jcK1uWrwpR67UhYrIFQ+5WlGxth34WquCbamhFA6hkkwiu37o6J5xCHdo1oixJRfVRw+ywV+Hq/0Aw==",
+      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
@@ -4502,6 +4576,7 @@
       "version": "5.18.3",
       "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.18.3.tgz",
       "integrity": "sha512-d4lC8xfavMeBjzGr2vECC3fsGXziXZQyJxD868h2M/mBI3PwAuODxAkLkq5HYuvrPYcUtiLzsTo8U3PgX3Ocww==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.2.4",
@@ -4583,6 +4658,7 @@
       "version": "0.25.10",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.10.tgz",
       "integrity": "sha512-9RiGKvCwaqxO2owP61uQ4BgNborAQskMR6QusfWzQqv7AZOg5oGehdY2pRJMTKuwxd1IDBP4rSbI5lHzU7SMsQ==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {
@@ -5079,6 +5155,7 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -5349,6 +5426,7 @@
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/graphemer": {
@@ -5732,6 +5810,7 @@
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.0.tgz",
       "integrity": "sha512-VXe6RjJkBPj0ohtqaO8vSWP3ZhAKo66fKrFNCll4BTcwljPLz03pCbaNKfzGP5MbrCYcbJ7v0nOYYwUzTEIdXQ==",
+      "dev": true,
       "license": "MIT",
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
@@ -5940,6 +6019,7 @@
       "version": "1.30.1",
       "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.30.1.tgz",
       "integrity": "sha512-xi6IyHML+c9+Q3W0S4fCQJOym42pyurFiJUHEcEyHS0CeKzia4yZDEsLlqOFykxOdHpNy0NmvVO31vcSqAxJCg==",
+      "dev": true,
       "license": "MPL-2.0",
       "dependencies": {
         "detect-libc": "^2.0.3"
@@ -5971,6 +6051,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -5991,6 +6072,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -6011,6 +6093,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -6031,6 +6114,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -6051,6 +6135,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -6071,6 +6156,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -6091,6 +6177,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -6111,6 +6198,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -6131,6 +6219,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -6151,6 +6240,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -6512,6 +6602,7 @@
       "version": "0.30.19",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.19.tgz",
       "integrity": "sha512-2N21sPY9Ws53PZvsEpVtNuSW+ScYbQdp4b9qUaL+9QkHUrGFKo56Lg9Emg5s9V/qrtNBmiR01sYhUOwu3H+VOw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
@@ -6862,6 +6953,7 @@
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
       "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
+      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=16 || 14 >=14.17"
@@ -6871,6 +6963,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.1.0.tgz",
       "integrity": "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "minipass": "^7.1.2"
@@ -6924,6 +7017,7 @@
       "version": "3.3.11",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
       "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -7169,6 +7263,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/picomatch": {
@@ -7211,6 +7306,7 @@
       "version": "8.5.6",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
       "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -7862,6 +7958,7 @@
       "version": "4.52.3",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.52.3.tgz",
       "integrity": "sha512-RIDh866U8agLgiIcdpB+COKnlCreHJLfIhWC3LVflku5YHfpnsIKigRZeFfMfCc4dVcqNVfQQ5gO/afOck064A==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/estree": "1.0.8"
@@ -8076,6 +8173,7 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
       "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
@@ -8449,12 +8547,14 @@
       "version": "4.1.13",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.1.13.tgz",
       "integrity": "sha512-i+zidfmTqtwquj4hMEwdjshYYgMbOrPzb9a0M3ZgNa0JMoZeFC6bxZvO8yr8ozS6ix2SDz0+mvryPeBs2TFE+w==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/tapable": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.3.tgz",
       "integrity": "sha512-ZL6DDuAlRlLGghwcfmSn9sK3Hr6ArtyudlSAiCqQ6IfE+b+HHbydbYDIG15IfS5do+7XQQBdBiubF/cV2dnDzg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -8468,6 +8568,7 @@
       "version": "7.5.1",
       "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.1.tgz",
       "integrity": "sha512-nlGpxf+hv0v7GkWBK2V9spgactGOp0qvfWRxUMjqHyzrt3SgwE48DIv/FhqPHJYLHpgW1opq3nERbz5Anq7n1g==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "@isaacs/fs-minipass": "^4.0.0",
@@ -8484,6 +8585,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
       "integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==",
+      "dev": true,
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=18"
@@ -8558,6 +8660,7 @@
       "version": "0.2.15",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
       "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fdir": "^6.5.0",
@@ -8574,6 +8677,7 @@
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
       "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12.0.0"
@@ -8591,6 +8695,7 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -8807,7 +8912,7 @@
       "version": "7.12.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.12.0.tgz",
       "integrity": "sha512-goOacqME2GYyOZZfb5Lgtu+1IDmAlAEu5xnD3+xTzS10hT0vzpf0SPjkXwAw9Jm+4n/mQGDP3LO8CPbYROeBfQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/update-browserslist-db": {
@@ -8933,6 +9038,7 @@
       "version": "7.1.7",
       "resolved": "https://registry.npmjs.org/vite/-/vite-7.1.7.tgz",
       "integrity": "sha512-VbA8ScMvAISJNJVbRDTJdCwqQoAareR/wutevKanhR2/1EkoXVZVkkORaYm/tNVCjP/UDTKtcw3bAkwOUdedmA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "esbuild": "^0.25.0",
@@ -9007,6 +9113,7 @@
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
       "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12.0.0"
@@ -9024,6 +9131,7 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -9130,7 +9238,7 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.1.tgz",
       "integrity": "sha512-lcYcMxX2PO9XMGvAJkJ3OsNMw+/7FKes7/hgerGUYWIoWu5j/+YQqcZr5JnPZWzOsEBgMbSbiSTn/dv/69Mkpw==",
-      "devOptional": true,
+      "dev": true,
       "license": "ISC",
       "bin": {
         "yaml": "bin.mjs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "app",
-  "version": "0.0.18",
+  "version": "0.0.19",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "app",
-      "version": "0.0.18",
+      "version": "0.0.19",
       "dependencies": {
         "@hookform/resolvers": "^5.2.2",
         "@monaco-editor/react": "^4.7.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "app",
-  "version": "0.0.17",
+  "version": "0.0.18",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "app",
-      "version": "0.0.17",
+      "version": "0.0.18",
       "dependencies": {
         "@hookform/resolvers": "^5.2.2",
         "@monaco-editor/react": "^4.7.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "app",
   "private": true,
-  "version": "0.0.17",
+  "version": "0.0.18",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "app",
   "private": true,
-  "version": "0.0.16",
+  "version": "0.0.17",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "app",
   "private": true,
-  "version": "0.0.18",
+  "version": "0.0.19",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/components/features/results/ChooseModel.tsx
+++ b/src/components/features/results/ChooseModel.tsx
@@ -1,0 +1,180 @@
+import { useState } from "react";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { useGetProjectsSimulationsQuery } from "@/store/projectApi";
+import type { ProjectSimulation } from "@/types/project";
+
+interface ChooseModelProps {
+  onModelSelect: (modelId: number, projectSimulation: ProjectSimulation) => void;
+  trigger: React.ReactElement;
+}
+
+export function ChooseModel({ onModelSelect, trigger }: ChooseModelProps) {
+  const [open, setOpen] = useState(false);
+  const [selectedGroup, setSelectedGroup] = useState<string>("");
+  const [selectedProjectId, setSelectedProjectId] = useState<string>("");
+  const [selectedModelId, setSelectedModelId] = useState<string>("");
+
+  const { data: projectsSimulations = [] } = useGetProjectsSimulationsQuery();
+
+  // Reset state when modal closes
+  const handleOpenChange = (open: boolean) => {
+    if (!open) {
+      setSelectedGroup("");
+      setSelectedProjectId("");
+      setSelectedModelId("");
+    }
+    setOpen(open);
+  };
+
+  // Get unique groups that have projects with simulations
+  const allGroupsWithProjects = Array.from(
+    new Set(
+      projectsSimulations
+        .filter((ps) => ps.simulations.length > 0)
+        .map((ps) => ps.group)
+        .filter(Boolean),
+    ),
+  );
+  allGroupsWithProjects.sort();
+
+  // Add "Ungrouped" only if there are ungrouped projects with simulations
+  const groups = [...allGroupsWithProjects];
+  if (projectsSimulations.some((ps) => !ps.group && ps.simulations.length > 0)) {
+    groups.push("Ungrouped");
+  }
+
+  // Get project simulations for selected group - only show projects that have simulations
+  const projectsInGroup =
+    selectedGroup === "Ungrouped"
+      ? projectsSimulations.filter((ps) => !ps.group && ps.simulations.length > 0)
+      : projectsSimulations.filter((ps) => ps.group === selectedGroup && ps.simulations.length > 0);
+
+  // Get selected project simulation
+  const selectedProjectSimulation = projectsSimulations.find(
+    (ps) => ps.projectId.toString() === selectedProjectId,
+  );
+
+  const handleGroupChange = (group: string) => {
+    setSelectedGroup(group);
+    setSelectedProjectId("");
+    setSelectedModelId("");
+  };
+
+  const handleProjectChange = (projectId: string) => {
+    setSelectedProjectId(projectId);
+    setSelectedModelId("");
+  };
+
+  const handleModelChange = (modelId: string) => {
+    setSelectedModelId(modelId);
+  };
+
+  const handleConfirm = () => {
+    if (selectedProjectSimulation && selectedModelId) {
+      onModelSelect(parseInt(selectedModelId), selectedProjectSimulation);
+      handleOpenChange(false);
+    }
+  };
+
+  const isConfirmEnabled = selectedGroup && selectedProjectId && selectedModelId;
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogTrigger asChild>{trigger}</DialogTrigger>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Choose Model</DialogTitle>
+        </DialogHeader>
+
+        <div className="space-y-4 mt-4">
+          {/* Group Select */}
+          <div className="space-y-2">
+            <label className="text-sm font-medium ">Group</label>
+            <Select value={selectedGroup} onValueChange={handleGroupChange}>
+              <SelectTrigger>
+                <SelectValue placeholder="Select a group" />
+              </SelectTrigger>
+              <SelectContent>
+                {groups.map((group) => (
+                  <SelectItem key={group} value={group}>
+                    {group} (
+                    {group === "Ungrouped"
+                      ? projectsSimulations.filter((ps) => !ps.group && ps.simulations.length > 0)
+                          .length
+                      : projectsSimulations.filter(
+                          (ps) => ps.group === group && ps.simulations.length > 0,
+                        ).length}{" "}
+                    projects)
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+
+          {/* Project Select - Only show if group is selected and has projects */}
+          {selectedGroup && projectsInGroup.length > 0 && (
+            <div className="space-y-2">
+              <label className="text-sm font-medium ">Project</label>
+              <Select value={selectedProjectId} onValueChange={handleProjectChange}>
+                <SelectTrigger>
+                  <SelectValue placeholder="Select a project" />
+                </SelectTrigger>
+                <SelectContent>
+                  {projectsInGroup.map((projectSim) => (
+                    <SelectItem key={projectSim.projectId} value={projectSim.projectId.toString()}>
+                      {projectSim.projectName} (Model: {projectSim.modelName})
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+          )}
+
+          {/* Model Select - Only show if project is selected */}
+          {selectedProjectId && selectedProjectSimulation && (
+            <div className="space-y-2">
+              <label className="text-sm font-medium ">Model</label>
+              <Select value={selectedModelId} onValueChange={handleModelChange}>
+                <SelectTrigger>
+                  <SelectValue placeholder="Select a model" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem
+                    key={selectedProjectSimulation.modelId}
+                    value={selectedProjectSimulation.modelId.toString()}
+                  >
+                    {selectedProjectSimulation.modelName}
+                  </SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+          )}
+
+          {/* Confirm Button */}
+          <div className="flex justify-end gap-2 pt-4">
+            <Button variant="outline" onClick={() => handleOpenChange(false)}>
+              Cancel
+            </Button>
+            <Button onClick={handleConfirm} disabled={!isConfirmEnabled}>
+              Confirm
+            </Button>
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/features/results/ChooseModel.tsx
+++ b/src/components/features/results/ChooseModel.tsx
@@ -110,7 +110,7 @@ export function ChooseModel({ onModelSelect, trigger }: ChooseModelProps) {
           <div className="space-y-2">
             <label className="text-sm font-medium ">Group</label>
             <Select value={selectedGroup} onValueChange={handleGroupChange}>
-              <SelectTrigger>
+              <SelectTrigger className="w-full">
                 <SelectValue placeholder="Select a group" />
               </SelectTrigger>
               <SelectContent>
@@ -135,7 +135,7 @@ export function ChooseModel({ onModelSelect, trigger }: ChooseModelProps) {
             <div className="space-y-2">
               <label className="text-sm font-medium ">Project</label>
               <Select value={selectedProjectId} onValueChange={handleProjectChange}>
-                <SelectTrigger>
+                <SelectTrigger className="w-full">
                   <SelectValue placeholder="Select a project" />
                 </SelectTrigger>
                 <SelectContent>
@@ -154,7 +154,7 @@ export function ChooseModel({ onModelSelect, trigger }: ChooseModelProps) {
             <div className="space-y-2">
               <label className="text-sm font-medium ">Model</label>
               <Select value={selectedModelId} onValueChange={handleModelChange}>
-                <SelectTrigger>
+                <SelectTrigger className="w-full">
                   <SelectValue placeholder="Select a model" />
                 </SelectTrigger>
                 <SelectContent>

--- a/src/components/features/results/CompareResult.tsx
+++ b/src/components/features/results/CompareResult.tsx
@@ -59,7 +59,7 @@ export function CompareResult({ modelId }: CompareResultProps) {
   };
 
   return (
-    <div>
+    <div className="overflow-y-auto h-container">
       <h2 className="font-choras text-2xl p-4 font-semibold text-choras-accent">Results</h2>
 
       {compareResults.map((result, idx) => (

--- a/src/components/features/results/CompareResult.tsx
+++ b/src/components/features/results/CompareResult.tsx
@@ -27,6 +27,7 @@ export function CompareResult({ modelId }: CompareResultProps) {
           {
             id: "1",
             simulationId: activeSimulation.id,
+            modelId: activeSimulation.modelId,
             sourceId:
               activeSimulation.sources.length > 0
                 ? activeSimulation.sources[0].id.toString()
@@ -48,6 +49,7 @@ export function CompareResult({ modelId }: CompareResultProps) {
     dispatch(
       addCompareResult({
         id: newId,
+        modelId: modelId,
         simulationId: null,
         sourceId: null,
         receiverId: null,
@@ -68,7 +70,7 @@ export function CompareResult({ modelId }: CompareResultProps) {
           sourceId={result.sourceId}
           receiverId={result.receiverId}
           color={result.color}
-          modelId={modelId}
+          modelId={result.modelId}
           isCurrent={idx === 0 && result.simulationId === activeSimulation?.id}
         />
       ))}

--- a/src/components/features/results/CompareResult.tsx
+++ b/src/components/features/results/CompareResult.tsx
@@ -69,7 +69,7 @@ export function CompareResult({ modelId }: CompareResultProps) {
           receiverId={result.receiverId}
           color={result.color}
           modelId={modelId}
-          canRemove={idx !== 0 && compareResults.length > 1}
+          isCurrent={idx === 0 && result.simulationId === activeSimulation?.id}
         />
       ))}
 

--- a/src/components/features/results/CompareResult.tsx
+++ b/src/components/features/results/CompareResult.tsx
@@ -5,19 +5,13 @@ import { addCompareResult, initializeCompareResults } from "@/store/simulationSl
 import type { RootState } from "@/store";
 import { useEffect } from "react";
 import { CompareResultItem } from "./CompareResultItem";
+import { COLORS } from "@/constants";
 
 interface CompareResultProps {
   modelId: number;
 }
 
-const COLORS = [
-  "bg-purple-500",
-  "bg-blue-500",
-  "bg-green-500",
-  "bg-yellow-500",
-  "bg-red-500",
-  "bg-pink-500",
-];
+const colorVariants = Object.values(COLORS);
 
 export function CompareResult({ modelId }: CompareResultProps) {
   const dispatch = useDispatch();
@@ -40,7 +34,7 @@ export function CompareResult({ modelId }: CompareResultProps) {
               activeSimulation.receivers.length > 0
                 ? activeSimulation.receivers[0].id.toString()
                 : null,
-            color: COLORS[0],
+            color: colorVariants[0],
           },
         ]),
       );
@@ -49,7 +43,7 @@ export function CompareResult({ modelId }: CompareResultProps) {
 
   const handleAddResult = () => {
     const newId = (compareResults.length + 1).toString();
-    const newColor = COLORS[compareResults.length % COLORS.length];
+    const newColor = colorVariants[compareResults.length % colorVariants.length];
     dispatch(
       addCompareResult({
         id: newId,

--- a/src/components/features/results/CompareResult.tsx
+++ b/src/components/features/results/CompareResult.tsx
@@ -6,6 +6,7 @@ import type { RootState } from "@/store";
 import { useEffect } from "react";
 import { CompareResultItem } from "./CompareResultItem";
 import { COLORS } from "@/constants";
+import { selectCompareResults } from "@/store/simulationSelector";
 
 interface CompareResultProps {
   modelId: number;
@@ -15,7 +16,7 @@ const colorVariants = Object.values(COLORS);
 
 export function CompareResult({ modelId }: CompareResultProps) {
   const dispatch = useDispatch();
-  const compareResults = useSelector((state: RootState) => state.simulation.compareResults);
+  const compareResults = useSelector(selectCompareResults);
   const activeSimulation = useSelector((state: RootState) => state.simulation.activeSimulation);
 
   // Initialize with one result if empty, using activeSimulation

--- a/src/components/features/results/CompareResult.tsx
+++ b/src/components/features/results/CompareResult.tsx
@@ -65,7 +65,7 @@ export function CompareResult({ modelId }: CompareResultProps) {
     <div>
       <h2 className="font-choras text-2xl p-4 font-semibold text-choras-accent">Results</h2>
 
-      {compareResults.map((result) => (
+      {compareResults.map((result, idx) => (
         <CompareResultItem
           key={result.id}
           id={result.id}
@@ -74,16 +74,12 @@ export function CompareResult({ modelId }: CompareResultProps) {
           receiverId={result.receiverId}
           color={result.color}
           modelId={modelId}
-          canRemove={compareResults.length > 1}
+          canRemove={idx !== 0 && compareResults.length > 1}
         />
       ))}
 
       <div className="m-4">
-        <Button
-          onClick={handleAddResult}
-          variant="outline"
-          className="w-full border-choras-accent text-choras-accent hover:bg-choras-accent hover:text-black"
-        >
+        <Button onClick={handleAddResult} variant="outline" className="w-full">
           <Plus size={20} className="mr-1" />
           Add result
         </Button>

--- a/src/components/features/results/CompareResult.tsx
+++ b/src/components/features/results/CompareResult.tsx
@@ -1,0 +1,93 @@
+import { Button } from "@/components/ui/button";
+import { Plus } from "lucide-react";
+import { useDispatch, useSelector } from "react-redux";
+import { addCompareResult, initializeCompareResults } from "@/store/simulationSlice";
+import type { RootState } from "@/store";
+import { useEffect } from "react";
+import { CompareResultItem } from "./CompareResultItem";
+
+interface CompareResultProps {
+  modelId: number;
+}
+
+const COLORS = [
+  "bg-purple-500",
+  "bg-blue-500",
+  "bg-green-500",
+  "bg-yellow-500",
+  "bg-red-500",
+  "bg-pink-500",
+];
+
+export function CompareResult({ modelId }: CompareResultProps) {
+  const dispatch = useDispatch();
+  const compareResults = useSelector((state: RootState) => state.simulation.compareResults);
+  const activeSimulation = useSelector((state: RootState) => state.simulation.activeSimulation);
+
+  // Initialize with one result if empty, using activeSimulation
+  useEffect(() => {
+    if (compareResults.length === 0 && activeSimulation) {
+      dispatch(
+        initializeCompareResults([
+          {
+            id: "1",
+            simulationId: activeSimulation.id,
+            sourceId:
+              activeSimulation.sources.length > 0
+                ? activeSimulation.sources[0].id.toString()
+                : null,
+            receiverId:
+              activeSimulation.receivers.length > 0
+                ? activeSimulation.receivers[0].id.toString()
+                : null,
+            color: COLORS[0],
+          },
+        ]),
+      );
+    }
+  }, [dispatch, compareResults.length, activeSimulation]);
+
+  const handleAddResult = () => {
+    const newId = (compareResults.length + 1).toString();
+    const newColor = COLORS[compareResults.length % COLORS.length];
+    dispatch(
+      addCompareResult({
+        id: newId,
+        simulationId: null,
+        sourceId: null,
+        receiverId: null,
+        color: newColor,
+      }),
+    );
+  };
+
+  return (
+    <div>
+      <h2 className="font-choras text-2xl p-4 font-semibold text-choras-accent">Results</h2>
+
+      {compareResults.map((result) => (
+        <CompareResultItem
+          key={result.id}
+          id={result.id}
+          simulationId={result.simulationId}
+          sourceId={result.sourceId}
+          receiverId={result.receiverId}
+          color={result.color}
+          modelId={modelId}
+          canRemove={compareResults.length > 1}
+        />
+      ))}
+
+      <div className="m-4">
+        <Button
+          onClick={handleAddResult}
+          variant="outline"
+          className="w-full border-choras-accent text-choras-accent hover:bg-choras-accent hover:text-black"
+        >
+          <Plus size={20} className="mr-1" />
+          Add result
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/features/results/CompareResultItem.tsx
+++ b/src/components/features/results/CompareResultItem.tsx
@@ -46,7 +46,13 @@ export function CompareResultItem({
   const [isDownloading, setIsDownloading] = useState(false);
   const dispatch = useDispatch();
   const { data: model } = useGetModelQuery(modelId?.toString(), { skip: !modelId });
-  const { data: simulations } = useGetSimulationsByModelIdQuery(modelId, { skip: !modelId });
+
+  console.log({ modelId });
+
+  const { data: simulations } = useGetSimulationsByModelIdQuery(modelId, {
+    skip: !modelId,
+    refetchOnMountOrArgChange: true,
+  });
   const { data: methods } = useGetSimulationMethodsQuery();
   const { data: results } = useGetSimulationResultQuery(simulationId!, {
     skip: !simulationId,

--- a/src/components/features/results/CompareResultItem.tsx
+++ b/src/components/features/results/CompareResultItem.tsx
@@ -22,6 +22,7 @@ import { downloadFile, formatFilename } from "@/helpers/file";
 import { toast } from "sonner";
 import { useState } from "react";
 import { useGetModelQuery } from "@/store/modelApi";
+import { ChooseModel } from "./ChooseModel";
 
 interface CompareResultItemProps {
   id: string;
@@ -136,7 +137,19 @@ export function CompareResultItem({
           <p className=" truncate">
             {model.projectName} {">"} {model.modelName}
           </p>
-          <p className="shrink underline">choose...</p>
+          <ChooseModel
+            onModelSelect={(model) => {
+              dispatch(
+                updateCompareResult({
+                  modelId: model.id,
+                  sourceId: null,
+                  receiverId: null,
+                  simulationId: null,
+                }),
+              );
+            }}
+            trigger={<p className="shrink underline">choose...</p>}
+          />
         </div>
       )}
 

--- a/src/components/features/results/CompareResultItem.tsx
+++ b/src/components/features/results/CompareResultItem.tsx
@@ -1,0 +1,236 @@
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Button } from "@/components/ui/button";
+import {
+  useGetSimulationResultQuery,
+  useGetSimulationsByModelIdQuery,
+} from "@/store/simulationApi";
+import { useGetSimulationMethodsQuery } from "@/store/simulationSettingsApi";
+import { formatDate } from "@/helpers/datetime";
+import { CheckCircleIcon, X } from "lucide-react";
+import type { Parameters, Simulation } from "@/types/simulation";
+import { useDispatch } from "react-redux";
+import { removeCompareResult, updateCompareResult } from "@/store/simulationSlice";
+import { http } from "@/libs/http";
+import { downloadFile, formatFilename } from "@/helpers/file";
+import { toast } from "sonner";
+import { useState } from "react";
+
+interface CompareResultItemProps {
+  id: string;
+  simulationId: number | null;
+  sourceId: string | null;
+  receiverId: string | null;
+  color: string;
+  modelId: number;
+  canRemove: boolean;
+}
+
+export function CompareResultItem({
+  id,
+  simulationId,
+  sourceId,
+  receiverId,
+  color,
+  modelId,
+  canRemove,
+}: CompareResultItemProps) {
+  const [isDownloading, setIsDownloading] = useState(false);
+  const dispatch = useDispatch();
+  const { data: simulations } = useGetSimulationsByModelIdQuery(modelId);
+  const { data: methods } = useGetSimulationMethodsQuery();
+  const { data: results } = useGetSimulationResultQuery(simulationId!, {
+    skip: !simulationId,
+  });
+
+  const selectedSimulation = simulations?.find((sim) => sim.id === simulationId);
+  const selectedMethod = selectedSimulation
+    ? methods?.find((method) => method.simulationType === selectedSimulation.taskType)
+    : null;
+
+  const handleUpdate = (field: string, value: unknown) => {
+    dispatch(updateCompareResult({ id, field, value }));
+  };
+
+  const handleRemove = () => {
+    dispatch(removeCompareResult(id));
+  };
+
+  const handleDownload = async () => {
+    if (!simulationId || !sourceId || !receiverId || !results) {
+      return;
+    }
+    try {
+      setIsDownloading(true);
+      const result = results[0];
+      const paramertes = result.responses[0].parameters;
+      const parameters = Object.keys(paramertes) as (keyof Parameters)[];
+      const availableFreqs = result.frequencies;
+      const output = {
+        xlsx: ["true"],
+        Parameters: parameters,
+        EDC: availableFreqs.map((freq) => `${freq}Hz`),
+        Auralization: ["wavIR", "csvIR"],
+        SimulationId: [simulationId],
+      };
+
+      // Request the export
+      const { data } = await http({
+        method: "POST",
+        url: "/exports/custom_export",
+        data: output,
+        responseType: "blob",
+      });
+
+      // Download the file
+      downloadFile(data, formatFilename(`simulation ${simulationId} results.zip`));
+
+      toast.success("Download started successfully");
+    } catch {
+      toast.error("Failed to start download");
+    } finally {
+      setIsDownloading(false);
+    }
+  };
+
+  // Get sources and receivers from selected simulation
+  const sources = selectedSimulation?.sources || [];
+  const receivers = selectedSimulation?.receivers || [];
+
+  return (
+    <div className="border-y border-stone-600 p-4 space-y-4 relative">
+      <div className="flex items-center gap-3">
+        <div className={`w-3 h-3 rounded-full ${color}`} />
+        <span className="text-white font-medium">Simulation</span>
+        <div className="flex-1">
+          <Select
+            value={simulationId?.toString()}
+            onValueChange={(value) => handleUpdate("simulationId", parseInt(value))}
+          >
+            <SelectTrigger className="bg-choras-dark text-white border-choras-gray [&>svg]:text-choras-gray w-full">
+              <SelectValue placeholder="Select simulation">
+                {selectedSimulation && selectedSimulation.completedAt && (
+                  <CheckCircleIcon className="inline mr-2 text-green-600" size={16} />
+                )}
+                {selectedSimulation ? selectedSimulation.name : "Simulation 1"}
+              </SelectValue>
+            </SelectTrigger>
+            <SelectContent className="bg-choras-dark border-choras-gray">
+              {simulations?.map((simulation) => (
+                <CustomSelectItem key={simulation.id} simulation={simulation} />
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+      </div>
+
+      {selectedMethod && (
+        <p className="text-white text-sm text-right">
+          Method: {selectedMethod.label.replace("method", "")}
+        </p>
+      )}
+
+      <div className="grid grid-cols-2 gap-4">
+        <div className="space-y-2">
+          <label className="text-white text-sm">Source</label>
+          <Select
+            disabled={!simulationId}
+            value={sourceId?.toString()}
+            onValueChange={(value) => handleUpdate("sourceId", value)}
+          >
+            <SelectTrigger className="bg-choras-dark text-white border-choras-gray [&>svg]:text-choras-gray w-full">
+              <SelectValue placeholder="Select source">
+                {sources.find((s) => s.id === sourceId?.toString())?.label || "Select source"}
+              </SelectValue>
+            </SelectTrigger>
+            <SelectContent className="bg-choras-dark border-choras-gray">
+              {sources.map((source) => (
+                <SelectItem
+                  key={source.id}
+                  value={source.id.toString()}
+                  className="bg-choras-dark hover:bg-choras-dark/90 active:bg-choras-dark/80 text-white"
+                >
+                  {source.label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+
+        <div className="space-y-2">
+          <label className="text-white text-sm">Receiver</label>
+          <Select
+            disabled={!simulationId}
+            value={receiverId?.toString()}
+            onValueChange={(value) => handleUpdate("receiverId", value)}
+          >
+            <SelectTrigger className="bg-choras-dark text-white border-choras-gray [&>svg]:text-choras-gray w-full">
+              <SelectValue placeholder="Select receiver">
+                {receivers.find((r) => r.id === receiverId?.toString())?.label || "Select receiver"}
+              </SelectValue>
+            </SelectTrigger>
+            <SelectContent className="bg-choras-dark border-choras-gray">
+              {receivers.map((receiver) => (
+                <SelectItem
+                  key={receiver.id}
+                  value={receiver.id.toString()}
+                  className="bg-choras-dark hover:bg-choras-dark/90 active:bg-choras-dark/80 text-white"
+                >
+                  {receiver.label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+      </div>
+
+      <div className="flex space-x-2">
+        {canRemove && (
+          <Button onClick={handleRemove} size="icon" variant="destructive">
+            <X size={20} />
+          </Button>
+        )}
+        <Button
+          variant="outline"
+          onClick={handleDownload}
+          className="flex-1 border-choras-accent text-choras-accent hover:bg-choras-accent hover:text-black"
+        >
+          {isDownloading ? "Downloading..." : "Download"}
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+function CustomSelectItem({ simulation }: { simulation: Simulation }) {
+  let timestamp = (
+    <p className="text-xs text-choras-gray">Created at: {formatDate(simulation.createdAt)}</p>
+  );
+
+  if (simulation.completedAt) {
+    timestamp = (
+      <p className="text-xs text-choras-gray inline-flex gap-2 items-center">
+        <CheckCircleIcon className="text-green-600" size={14} /> Completed at:{" "}
+        {formatDate(simulation.completedAt)}
+      </p>
+    );
+  }
+
+  return (
+    <SelectItem
+      key={simulation.id}
+      value={simulation.id.toString()}
+      className="bg-choras-dark hover:bg-choras-dark/90 active:bg-choras-dark/80"
+    >
+      <div className="flex flex-col gap-1">
+        <p className="text-choras-gray">{simulation.name}</p>
+        {timestamp}
+      </div>
+    </SelectItem>
+  );
+}

--- a/src/components/features/results/CompareResultItem.tsx
+++ b/src/components/features/results/CompareResultItem.tsx
@@ -98,6 +98,25 @@ export function CompareResultItem({
     }
   };
 
+  const handleSimulationIdChange = (value: string) => {
+    const newSimulationId = parseInt(value);
+    handleUpdate("simulationId", newSimulationId);
+
+    // Find the selected simulation and auto-select first source and receiver
+    const simulation = simulations?.find((sim) => sim.id === newSimulationId);
+    if (simulation) {
+      const firstSourceId = simulation.sources?.[0]?.id || null;
+      const firstReceiverId = simulation.receivers?.[0]?.id || null;
+
+      if (firstSourceId) {
+        handleUpdate("sourceId", firstSourceId);
+      }
+      if (firstReceiverId) {
+        handleUpdate("receiverId", firstReceiverId);
+      }
+    }
+  };
+
   // Get sources and receivers from selected simulation
   const sources = selectedSimulation?.sources || [];
   const receivers = selectedSimulation?.receivers || [];
@@ -108,10 +127,7 @@ export function CompareResultItem({
         <div className={`w-3 h-3 rounded-full ${color}`} />
         <span className="text-white font-medium">Simulation</span>
         <div className="flex-1">
-          <Select
-            value={simulationId?.toString()}
-            onValueChange={(value) => handleUpdate("simulationId", parseInt(value))}
-          >
+          <Select value={simulationId?.toString()} onValueChange={handleSimulationIdChange}>
             <SelectTrigger className="bg-choras-dark text-white border-choras-gray [&>svg]:text-choras-gray w-full">
               <SelectValue placeholder="Select simulation">
                 {selectedSimulation && selectedSimulation.completedAt && (

--- a/src/components/features/results/CompareResultItem.tsx
+++ b/src/components/features/results/CompareResultItem.tsx
@@ -124,7 +124,7 @@ export function CompareResultItem({
   return (
     <div className="border-y border-stone-600 p-4 space-y-4 relative">
       <div className="flex items-center gap-3">
-        <div className={`w-3 h-3 rounded-full ${color}`} />
+        <div className={`w-3 h-3 rounded-full`} style={{ backgroundColor: color }} />
         <span className="text-white font-medium">Simulation</span>
         <div className="flex-1">
           <Select value={simulationId?.toString()} onValueChange={handleSimulationIdChange}>

--- a/src/components/features/results/CompareResultItem.tsx
+++ b/src/components/features/results/CompareResultItem.tsx
@@ -21,6 +21,7 @@ import { http } from "@/libs/http";
 import { downloadFile, formatFilename } from "@/helpers/file";
 import { toast } from "sonner";
 import { useState } from "react";
+import { useGetModelQuery } from "@/store/modelApi";
 
 interface CompareResultItemProps {
   id: string;
@@ -43,7 +44,8 @@ export function CompareResultItem({
 }: CompareResultItemProps) {
   const [isDownloading, setIsDownloading] = useState(false);
   const dispatch = useDispatch();
-  const { data: simulations } = useGetSimulationsByModelIdQuery(modelId);
+  const { data: model } = useGetModelQuery(modelId?.toString(), { skip: !modelId });
+  const { data: simulations } = useGetSimulationsByModelIdQuery(modelId, { skip: !modelId });
   const { data: methods } = useGetSimulationMethodsQuery();
   const { data: results } = useGetSimulationResultQuery(simulationId!, {
     skip: !simulationId,
@@ -125,22 +127,26 @@ export function CompareResultItem({
   const sources = selectedSimulation?.sources || [];
   const receivers = selectedSimulation?.receivers || [];
 
+  console.log(model, "<<<");
+
   return (
     <div className="border-y border-stone-600 p-4 space-y-4 relative">
-      <div className="flex items-center gap-3">
+      {model && (
+        <div className="text-xs flex items-center justify-between gap-3 font-inter text-white/60">
+          <p className=" truncate">
+            {model.projectName} {">"} {model.modelName}
+          </p>
+          <p className="shrink underline">choose...</p>
+        </div>
+      )}
+
+      <div className="flex items-center">
         <div className={`w-3 h-3 rounded-full`} style={{ backgroundColor: color }} />
-        <span className="text-white font-medium">Simulation</span>
-        <div className="flex-1">
-          <Select
-            disabled={isCurrent}
-            value={simulationId?.toString()}
-            onValueChange={handleSimulationIdChange}
-          >
+        <span className="text-white text-base font-inter font-normal ml-3">Simulation</span>
+        <div className="flex-1 ml-8">
+          <Select value={simulationId?.toString()} onValueChange={handleSimulationIdChange}>
             <SelectTrigger className="bg-choras-dark text-white border-choras-gray [&>svg]:text-choras-gray w-full">
               <SelectValue placeholder="Select simulation">
-                {selectedSimulation && selectedSimulation.completedAt && (
-                  <CheckCircleIcon className="inline mr-2 text-green-600" size={16} />
-                )}
                 {selectedSimulation ? selectedSimulation.name : "Simulation 1"}
               </SelectValue>
             </SelectTrigger>
@@ -154,14 +160,14 @@ export function CompareResultItem({
       </div>
 
       {selectedMethod && (
-        <p className="text-white text-sm text-right">
+        <p className="text-white/60 text-xs text-right">
           Method: {selectedMethod.label.replace("method", "")}
         </p>
       )}
 
       <div className="grid grid-cols-2 gap-4">
-        <div className="space-y-2">
-          <label className="text-white text-sm">Source</label>
+        <div className="flex flex-col space-y-2">
+          <label className="text-white/60 text-xs">Source</label>
           <Select
             disabled={!simulationId}
             value={sourceId?.toString()}
@@ -186,8 +192,8 @@ export function CompareResultItem({
           </Select>
         </div>
 
-        <div className="space-y-2">
-          <label className="text-white text-sm">Receiver</label>
+        <div className="flex flex-col space-y-2">
+          <label className="text-white/60 text-xs">Receiver</label>
           <Select
             disabled={!simulationId}
             value={receiverId?.toString()}

--- a/src/components/features/results/CompareResultItem.tsx
+++ b/src/components/features/results/CompareResultItem.tsx
@@ -29,7 +29,7 @@ interface CompareResultItemProps {
   receiverId: string | null;
   color: string;
   modelId: number;
-  canRemove: boolean;
+  isCurrent: boolean;
 }
 
 export function CompareResultItem({
@@ -39,7 +39,7 @@ export function CompareResultItem({
   receiverId,
   color,
   modelId,
-  canRemove,
+  isCurrent,
 }: CompareResultItemProps) {
   const [isDownloading, setIsDownloading] = useState(false);
   const dispatch = useDispatch();
@@ -131,7 +131,11 @@ export function CompareResultItem({
         <div className={`w-3 h-3 rounded-full`} style={{ backgroundColor: color }} />
         <span className="text-white font-medium">Simulation</span>
         <div className="flex-1">
-          <Select value={simulationId?.toString()} onValueChange={handleSimulationIdChange}>
+          <Select
+            disabled={isCurrent}
+            value={simulationId?.toString()}
+            onValueChange={handleSimulationIdChange}
+          >
             <SelectTrigger className="bg-choras-dark text-white border-choras-gray [&>svg]:text-choras-gray w-full">
               <SelectValue placeholder="Select simulation">
                 {selectedSimulation && selectedSimulation.completedAt && (
@@ -210,7 +214,7 @@ export function CompareResultItem({
       </div>
 
       <div className="flex space-x-2">
-        {canRemove && (
+        {!isCurrent && (
           <Button onClick={handleRemove} size="icon" variant="destructive">
             <X size={20} />
           </Button>

--- a/src/components/features/results/CompareResultItem.tsx
+++ b/src/components/features/results/CompareResultItem.tsx
@@ -9,6 +9,7 @@ import { Button } from "@/components/ui/button";
 import {
   useGetSimulationResultQuery,
   useGetSimulationsByModelIdQuery,
+  useLazyGetSimulationResultQuery,
 } from "@/store/simulationApi";
 import { useGetSimulationMethodsQuery } from "@/store/simulationSettingsApi";
 import { formatDate } from "@/helpers/datetime";
@@ -47,6 +48,7 @@ export function CompareResultItem({
   const { data: results } = useGetSimulationResultQuery(simulationId!, {
     skip: !simulationId,
   });
+  const [getSimulationResult] = useLazyGetSimulationResultQuery();
 
   const selectedSimulation = simulations?.find((sim) => sim.id === simulationId);
   const selectedMethod = selectedSimulation
@@ -105,6 +107,8 @@ export function CompareResultItem({
     // Find the selected simulation and auto-select first source and receiver
     const simulation = simulations?.find((sim) => sim.id === newSimulationId);
     if (simulation) {
+      getSimulationResult(newSimulationId);
+
       const firstSourceId = simulation.sources?.[0]?.id || null;
       const firstReceiverId = simulation.receivers?.[0]?.id || null;
 

--- a/src/components/features/results/CompareResultItem.tsx
+++ b/src/components/features/results/CompareResultItem.tsx
@@ -138,15 +138,11 @@ export function CompareResultItem({
             {model.projectName} {">"} {model.modelName}
           </p>
           <ChooseModel
-            onModelSelect={(model) => {
-              dispatch(
-                updateCompareResult({
-                  modelId: model.id,
-                  sourceId: null,
-                  receiverId: null,
-                  simulationId: null,
-                }),
-              );
+            onModelSelect={(modelId) => {
+              handleUpdate("modelId", modelId);
+              handleUpdate("simulationId", null);
+              handleUpdate("sourceId", null);
+              handleUpdate("receiverId", null);
             }}
             trigger={<p className="shrink underline">choose...</p>}
           />
@@ -160,7 +156,7 @@ export function CompareResultItem({
           <Select value={simulationId?.toString()} onValueChange={handleSimulationIdChange}>
             <SelectTrigger className="bg-choras-dark text-white border-choras-gray [&>svg]:text-choras-gray w-full">
               <SelectValue placeholder="Select simulation">
-                {selectedSimulation ? selectedSimulation.name : "Simulation 1"}
+                {selectedSimulation ? selectedSimulation.name : "Select simulation"}
               </SelectValue>
             </SelectTrigger>
             <SelectContent className="bg-choras-dark border-choras-gray">

--- a/src/components/features/results/DownloadResult.tsx
+++ b/src/components/features/results/DownloadResult.tsx
@@ -34,7 +34,9 @@ export function DownloadResult({ simulationIds, mode, triggerLabel }: DownloadRe
   const allSections = ["parameters", "plots", "auralizations"];
   const visibleSections = mode ? [mode] : allSections;
 
-  const { data: simulationResult, isLoading } = useGetSimulationResultQuery(simulationIds[0]);
+  const { data: simulationResult, isLoading } = useGetSimulationResultQuery(simulationIds[0], {
+    skip: simulationIds.length === 0,
+  });
 
   // Checkbox states
   const [parameters, setParameters] = useState(false);

--- a/src/components/features/results/DownloadResult.tsx
+++ b/src/components/features/results/DownloadResult.tsx
@@ -22,19 +22,19 @@ import { downloadFile, formatFilename } from "@/helpers/file";
 import { cn } from "@/libs/style";
 
 type DownloadResultProps = {
-  simulationId: number;
+  simulationIds: number[];
   mode?: "parameters" | "plots" | "auralizations";
   triggerLabel?: string;
 };
 
-export function DownloadResult({ simulationId, mode, triggerLabel }: DownloadResultProps) {
+export function DownloadResult({ simulationIds, mode, triggerLabel }: DownloadResultProps) {
   const [open, setOpen] = useState(false);
   const [isDownloading, setIsDownloading] = useState(false);
 
   const allSections = ["parameters", "plots", "auralizations"];
   const visibleSections = mode ? [mode] : allSections;
 
-  const { data: simulationResult, isLoading } = useGetSimulationResultQuery(simulationId);
+  const { data: simulationResult, isLoading } = useGetSimulationResultQuery(simulationIds[0]);
 
   // Checkbox states
   const [parameters, setParameters] = useState(false);
@@ -77,7 +77,7 @@ export function DownloadResult({ simulationId, mode, triggerLabel }: DownloadRes
       // Build the output in the required format
       const output: Record<string, (string | number)[]> = {
         xlsx: ["true"],
-        SimulationId: [simulationId], // TODO: if comparison panel is added, this should be SimulationIds of compared simulations
+        SimulationId: simulationIds, // TODO: if comparison panel is added, this should be SimulationIds of compared simulations
         Parameters: [],
         EDC: [],
         Auralization: [],
@@ -116,7 +116,7 @@ export function DownloadResult({ simulationId, mode, triggerLabel }: DownloadRes
       });
 
       // Download the file
-      downloadFile(data, formatFilename(`simulation ${simulationId} results.zip`));
+      downloadFile(data, formatFilename(`simulation ${simulationIds.join(",")} results.zip`));
 
       toast.success("Download started successfully");
       setOpen(false);

--- a/src/components/features/results/ImpulseResponsePlayer.tsx
+++ b/src/components/features/results/ImpulseResponsePlayer.tsx
@@ -11,8 +11,9 @@ import { Loading } from "@/components/ui/loading";
 
 type ImpulseResponsePlayerProps = {
   simulationId: number;
+  color: string;
 };
-export function ImpulseResponsePlayer({ simulationId }: ImpulseResponsePlayerProps) {
+export function ImpulseResponsePlayer({ simulationId, color }: ImpulseResponsePlayerProps) {
   const {
     data: impulseResponse,
     isLoading,
@@ -50,7 +51,7 @@ export function ImpulseResponsePlayer({ simulationId }: ImpulseResponsePlayerPro
     <div className="w-full flex flex-col gap-4">
       <WavesurferPlayer
         height={100}
-        waveColor="darkseagreen"
+        waveColor={color}
         url={audioUrl}
         onReady={(ws) => (wsRef.current = ws)}
       />

--- a/src/components/features/results/ResultAuralizations.tsx
+++ b/src/components/features/results/ResultAuralizations.tsx
@@ -5,6 +5,8 @@ import { DownloadResult } from "./DownloadResult";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Loading } from "@/components/ui/loading";
 import { useGetAuralizationsBySimulationIdQuery } from "@/store/auralizationApi";
+import { useSelector } from "react-redux";
+import type { RootState } from "@/store";
 
 type ResultAuralizationsProps = {
   simulationId: number;
@@ -15,6 +17,7 @@ export function ResultAuralizations({ simulationId }: ResultAuralizationsProps) 
     isLoading,
     isError,
   } = useGetAuralizationsBySimulationIdQuery(simulationId);
+  const compareResults = useSelector((state: RootState) => state.simulation.compareResults);
 
   if (isLoading) {
     return <Loading message="Loading audio files..." className="h-container justify-center" />;
@@ -49,7 +52,16 @@ export function ResultAuralizations({ simulationId }: ResultAuralizationsProps) 
           mode="auralizations"
         />
       </div>
-      <ImpulseResponsePlayer simulationId={simulationId} />
+      {compareResults.map(
+        (result) =>
+          result.simulationId && (
+            <ImpulseResponsePlayer
+              key={`ir-player-${result.id}-${result.simulationId}`}
+              simulationId={result.simulationId}
+              color={result.color}
+            />
+          ),
+      )}
 
       <div className="flex justify-between mt-12">
         <h1 className="text-2xl text-choras-secondary font-inter font-bold">Convolved Sound</h1>

--- a/src/components/features/results/ResultAuralizations.tsx
+++ b/src/components/features/results/ResultAuralizations.tsx
@@ -6,7 +6,7 @@ import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Loading } from "@/components/ui/loading";
 import { useGetAuralizationsBySimulationIdQuery } from "@/store/auralizationApi";
 import { useSelector } from "react-redux";
-import type { RootState } from "@/store";
+import { selectCompareSimulationIds, selectCompareResults } from "@/store/simulationSelector";
 
 type ResultAuralizationsProps = {
   simulationId: number;
@@ -17,7 +17,10 @@ export function ResultAuralizations({ simulationId }: ResultAuralizationsProps) 
     isLoading,
     isError,
   } = useGetAuralizationsBySimulationIdQuery(simulationId);
-  const compareResults = useSelector((state: RootState) => state.simulation.compareResults);
+  const compareResults = useSelector(selectCompareResults);
+  const compareResultIds = useSelector(selectCompareSimulationIds);
+
+  console.log(compareResultIds, "<<<");
 
   if (isLoading) {
     return <Loading message="Loading audio files..." className="h-container justify-center" />;
@@ -48,7 +51,7 @@ export function ResultAuralizations({ simulationId }: ResultAuralizationsProps) 
 
         <DownloadResult
           triggerLabel="Download Impulse Response"
-          simulationId={simulationId}
+          simulationIds={compareResultIds}
           mode="auralizations"
         />
       </div>

--- a/src/components/features/results/ResultParameters.tsx
+++ b/src/components/features/results/ResultParameters.tsx
@@ -27,7 +27,6 @@ export function ResultParameters({ simulationId }: ResultParametersProps) {
   const { data: results, isLoading, error } = useGetSimulationResultQuery(simulationId);
   const { data: simulation } = useGetSimulationByIdQuery(simulationId);
 
-  // FIX: get series data based on active compareResults id
   const seriesData = useSelector(selectCompareResultsSeriesData(selectedParameter));
   const compareResultIds = useSelector(selectCompareSimulationIds);
 

--- a/src/components/features/results/ResultParameters.tsx
+++ b/src/components/features/results/ResultParameters.tsx
@@ -13,7 +13,10 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import { selectCompareResultsSeriesData } from "@/store/simulationSelector";
+import {
+  selectCompareSimulationIds,
+  selectCompareResultsSeriesData,
+} from "@/store/simulationSelector";
 import { useSelector } from "react-redux";
 
 type ResultParametersProps = {
@@ -26,6 +29,7 @@ export function ResultParameters({ simulationId }: ResultParametersProps) {
   const seriesData = useSelector(
     selectCompareResultsSeriesData(selectedParameter, simulation?.modelId),
   );
+  const compareResultIds = useSelector(selectCompareSimulationIds);
 
   if (isLoading) return <Loading className="h-container justify-center" />;
 
@@ -70,7 +74,7 @@ export function ResultParameters({ simulationId }: ResultParametersProps) {
           </SelectContent>
         </Select>
 
-        <DownloadResult simulationId={+simulationId} mode="parameters" />
+        <DownloadResult simulationIds={compareResultIds} mode="parameters" />
       </div>
 
       <div className="border border-black p-2 rounded-sm">

--- a/src/components/features/results/ResultParameters.tsx
+++ b/src/components/features/results/ResultParameters.tsx
@@ -26,9 +26,9 @@ export function ResultParameters({ simulationId }: ResultParametersProps) {
   const [selectedParameter, setSelectedParameter] = useState<keyof Parameters>("edt");
   const { data: results, isLoading, error } = useGetSimulationResultQuery(simulationId);
   const { data: simulation } = useGetSimulationByIdQuery(simulationId);
-  const seriesData = useSelector(
-    selectCompareResultsSeriesData(selectedParameter, simulation?.modelId),
-  );
+
+  // FIX: get series data based on active compareResults id
+  const seriesData = useSelector(selectCompareResultsSeriesData(selectedParameter));
   const compareResultIds = useSelector(selectCompareSimulationIds);
 
   if (isLoading) return <Loading className="h-container justify-center" />;

--- a/src/components/features/simulationSettings/CreateMaterialDialog.tsx
+++ b/src/components/features/simulationSettings/CreateMaterialDialog.tsx
@@ -1,0 +1,199 @@
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import { Plus } from "lucide-react";
+import { useState } from "react";
+import { useCreateMaterialMutation } from "@/store/materialsApi";
+import { toast } from "sonner";
+
+export function CreateMaterialDialog() {
+  const [open, setOpen] = useState(false);
+  const [createMaterial, { isLoading: isCreating }] = useCreateMaterialMutation();
+
+  const [formData, setFormData] = useState({
+    name: "",
+    description: "",
+    category: "",
+    absorptionCoefficients: [0.01, 0.04, 0.14, 0.47, 0.88, 0.53, 0.26],
+  });
+
+  const handleInputChange = (field: string, value: string | number[]) => {
+    setFormData((prev) => ({ ...prev, [field]: value }));
+  };
+
+  const handleCoeffChange = (index: number, value: string) => {
+    const newCoeffs = [...formData.absorptionCoefficients];
+    newCoeffs[index] = parseFloat(value) || 0;
+    setFormData((prev) => ({ ...prev, absorptionCoefficients: newCoeffs }));
+  };
+
+  const frequencyLabels = ["63Hz", "125Hz", "250Hz", "500Hz", "1kHz", "2kHz", "4kHz"];
+
+  const handleSliderClick = (index: number, event: React.MouseEvent<HTMLDivElement>) => {
+    const rect = event.currentTarget.getBoundingClientRect();
+    const y = event.clientY - rect.top;
+    const height = rect.height;
+    const percentage = 1 - y / height; // Invert because top = high value
+    const newValue = Math.max(0, Math.min(1, percentage));
+    const roundedValue = Math.round(newValue * 100) / 100;
+    handleCoeffChange(index, roundedValue.toString());
+  };
+
+  const handleCreateSubmit = async () => {
+    try {
+      await createMaterial(formData).unwrap();
+      toast.success("Material created successfully!");
+      setOpen(false);
+      setFormData({
+        name: "",
+        description: "",
+        category: "",
+        absorptionCoefficients: [0.01, 0.04, 0.14, 0.47, 0.88, 0.53, 0.26],
+      });
+    } catch (error) {
+      toast.error("Failed to create material");
+      console.error("Error creating material:", error);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild>
+        <Button variant="outline" size="sm" className="flex items-center gap-2">
+          <Plus size={16} />
+          Create Material
+        </Button>
+      </DialogTrigger>
+      <DialogContent className="sm:max-w-2xl">
+        <DialogHeader>
+          <DialogTitle>Create New Material</DialogTitle>
+          <DialogDescription>Add a new material with acoustic properties</DialogDescription>
+        </DialogHeader>
+        <div className="grid gap-4 py-4">
+          <div className="grid grid-cols-4 items-center gap-4">
+            <Label htmlFor="name">Name</Label>
+            <Input
+              id="name"
+              value={formData.name}
+              onChange={(e) => handleInputChange("name", e.target.value)}
+              className="col-span-3"
+              placeholder="Material name"
+            />
+          </div>
+          <div className="grid grid-cols-4 items-center gap-4">
+            <Label htmlFor="category">Category</Label>
+            <Input
+              id="category"
+              value={formData.category}
+              onChange={(e) => handleInputChange("category", e.target.value)}
+              className="col-span-3"
+              placeholder="Material category"
+            />
+          </div>
+          <div className="grid grid-cols-4 items-start gap-4">
+            <Label htmlFor="description" className="text-right mt-2">
+              Description
+            </Label>
+            <Textarea
+              id="description"
+              value={formData.description}
+              onChange={(e) => handleInputChange("description", e.target.value)}
+              className="col-span-3"
+              placeholder="Material description"
+              rows={3}
+            />
+          </div>
+          <div className="grid grid-cols-4 items-start gap-4">
+            <Label className="mt-2">Absorption Coefficients</Label>
+            <div className="col-span-3">
+              <div className="bg-gray-50 p-4 rounded-lg border">
+                <div className="flex justify-center items-end gap-3 h-44">
+                  {formData.absorptionCoefficients.map((coeff, index) => (
+                    <div key={index} className="flex flex-col items-center gap-1">
+                      <Input
+                        type="number"
+                        step="0.01"
+                        min="0"
+                        max="1"
+                        value={coeff}
+                        onChange={(e) => handleCoeffChange(index, e.target.value)}
+                        className="w-12 h-6 text-center text-xs px-1 py-0 [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none [-moz-appearance:textfield]"
+                      />
+
+                      <div className="relative h-32 w-8 flex justify-center">
+                        <div
+                          className="relative h-32 w-3 bg-choras-gray rounded cursor-pointer border border-gray-300"
+                          onClick={(e) => handleSliderClick(index, e)}
+                        >
+                          <div
+                            className="absolute w-5 h-4 bg-white border-2 border-gray-700 rounded-sm cursor-grab shadow-lg transform -translate-x-1/2 -translate-y-1/2"
+                            style={{
+                              left: "50%",
+                              top: `${(1 - coeff) * 100}%`,
+                            }}
+                            onMouseDown={(e) => {
+                              e.preventDefault();
+                              const startY = e.clientY;
+                              const startValue = coeff;
+                              const slider = e.currentTarget.parentElement!;
+                              const sliderRect = slider.getBoundingClientRect();
+
+                              const handleMouseMove = (e: MouseEvent) => {
+                                const deltaY = e.clientY - startY;
+                                const deltaPercentage = deltaY / sliderRect.height;
+                                const newValue = Math.max(
+                                  0,
+                                  Math.min(1, startValue - deltaPercentage),
+                                );
+                                const roundedValue = Math.round(newValue * 100) / 100; // Round to 2 decimal places
+                                handleCoeffChange(index, roundedValue.toString());
+                              };
+
+                              const handleMouseUp = () => {
+                                document.removeEventListener("mousemove", handleMouseMove);
+                                document.removeEventListener("mouseup", handleMouseUp);
+                              };
+
+                              document.addEventListener("mousemove", handleMouseMove);
+                              document.addEventListener("mouseup", handleMouseUp);
+                            }}
+                          />
+                        </div>
+                      </div>
+
+                      <div className="text-xs font-medium text-gray-600 text-center">
+                        {frequencyLabels[index]}
+                      </div>
+                    </div>
+                  ))}
+                </div>
+                <div className="mt-4 text-xs text-gray-500 text-center">
+                  Drag sliders to adjust absorption coefficients (0.00 - 1.00)
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <DialogFooter>
+          <Button
+            type="submit"
+            onClick={handleCreateSubmit}
+            disabled={isCreating || !formData.name || !formData.category}
+          >
+            {isCreating ? "Creating..." : "Create Material"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/features/simulationSettings/SurfaceMaterialList.tsx
+++ b/src/components/features/simulationSettings/SurfaceMaterialList.tsx
@@ -13,6 +13,7 @@ import { EllipsisVertical, Search } from "lucide-react";
 import { useState } from "react";
 import { useGetMaterialsQuery } from "@/store/materialsApi";
 import type { Material } from "@/types/material";
+import { CreateMaterialDialog } from "./CreateMaterialDialog";
 
 export function SurfaceMaterialList() {
   const [open, setOpen] = useState(false);
@@ -23,6 +24,7 @@ export function SurfaceMaterialList() {
   const filteredMaterials = materials.filter((material) =>
     material.name.toLowerCase().includes(searchQuery.toLowerCase()),
   );
+
   return (
     <Dialog open={open} onOpenChange={setOpen}>
       <DialogTrigger asChild>
@@ -33,7 +35,10 @@ export function SurfaceMaterialList() {
       <DialogContent className="sm:max-w-3xl max-w-lg border border-transparent bg-gradient-to-r from-choras-primary from-50% to-choras-secondary bg-clip-border p-0.5">
         <div className="bg-white p-6 rounded-lg space-y-6">
           <DialogHeader>
-            <DialogTitle className="text-xl text-choras-primary">Materials</DialogTitle>
+            <div className="flex justify-between items-center mt-4">
+              <DialogTitle className="text-xl text-choras-primary">Materials</DialogTitle>
+              <CreateMaterialDialog />
+            </div>
             <DialogDescription>List of Material Available</DialogDescription>
           </DialogHeader>
 

--- a/src/components/features/simulationSettings/SurfacesTab.tsx
+++ b/src/components/features/simulationSettings/SurfacesTab.tsx
@@ -19,13 +19,14 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import type { SurfaceInfo } from "@/types/material";
-import { ChevronRight } from "lucide-react";
+import { ChevronRight, Eye, EyeOff } from "lucide-react";
 import { SurfaceMaterialList } from "./SurfaceMaterialList";
 
 export function SurfacesTab() {
   const dispatch = useDispatch();
   const surfaces = useSurfaces();
   const [showIndividualAssignments, setShowIndividualAssignments] = useState(false);
+  const [hiddenSurfaces, setHiddenSurfaces] = useState<Set<string>>(new Set());
   const {
     data: materials = [],
     isLoading: materialsLoading,
@@ -173,6 +174,26 @@ export function SurfacesTab() {
     return "default";
   };
 
+  const toggleSurfaceVisibility = (surfaceId: string) => {
+    setHiddenSurfaces((prev) => {
+      const newSet = new Set(prev);
+      if (newSet.has(surfaceId)) {
+        newSet.delete(surfaceId);
+      } else {
+        newSet.add(surfaceId);
+      }
+      return newSet;
+    });
+  };
+
+  useEffect(() => {
+    surfaces.forEach((surface) => {
+      if (surface.mesh) {
+        surface.mesh.visible = !hiddenSurfaces.has(surface.id);
+      }
+    });
+  }, [surfaces, hiddenSurfaces]);
+
   return (
     <div className="text-white">
       <div className="mb-4 flex justify-between items-center">
@@ -187,10 +208,10 @@ export function SurfacesTab() {
           <table className="w-full table-fixed">
             <thead>
               <tr>
-                <th className="px-3 py-2 text-left text-xs font-medium text-gray-300 uppercase tracking-wider w-1/2">
+                <th className="px-3 py-2 text-left text-xs font-medium text-gray-300 uppercase tracking-wider w-1/3">
                   Surface
                 </th>
-                <th className="px-3 py-2 text-left text-xs font-medium text-gray-300 uppercase tracking-wider w-1/2">
+                <th className="px-3 py-2 text-left text-xs font-medium text-gray-300 uppercase tracking-wider w-1/3">
                   Material
                 </th>
               </tr>
@@ -259,9 +280,23 @@ export function SurfacesTab() {
                       className="hover:bg-choras-dark/90 border-t border-gray-700"
                     >
                       <td className="px-3 py-2 text-sm w-1/3">
-                        <div className="font-medium">{getDisplayName(surface, index)}</div>
+                        <div className="flex items-center gap-2">
+                          <div
+                            onClick={() => toggleSurfaceVisibility(surfaceKey)}
+                            className="cursor-pointer text-white hover:text-gray-300 transition-colors flex-shrink-0"
+                          >
+                            {hiddenSurfaces.has(surfaceKey) ? (
+                              <EyeOff className="h-4 w-4" />
+                            ) : (
+                              <Eye className="h-4 w-4" />
+                            )}
+                          </div>
+                          <div className="font-medium truncate">
+                            {getDisplayName(surface, index)}
+                          </div>
+                        </div>
                       </td>
-                      <td className="px-3 py-2 w-2/3">
+                      <td className="px-3 py-2 w-1/3">
                         <Select
                           value={assignedMaterialId?.toString() || "default"}
                           onValueChange={(value) => handleMaterialAssignment(surfaceKey, value)}

--- a/src/components/features/viewport/ViewportCanvas.tsx
+++ b/src/components/features/viewport/ViewportCanvas.tsx
@@ -10,9 +10,17 @@ import { ReceiverVisualization } from "./ReceiverVisualization";
 import { RunSimulationButton } from "./RunSimulationButton";
 import type { ViewportCanvasProps } from "@/types/modelViewport";
 import { OrbitControls as OrbitControlsType } from "three-stdlib";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 
 export function ViewportCanvas({ modelUrl, modelId }: ViewportCanvasProps) {
   const [cameraType, setCameraType] = useState<"perspective" | "orthographic">("perspective");
+  const [viewMode, setViewMode] = useState<"solid" | "ghosted" | "wireframe">("solid");
   const { loadModelFromUrl, isModelLoaded, isLoading, error, setActiveModel } = useModelLoader();
   const orbitControlsRef = useRef<OrbitControlsType | null>(null);
 
@@ -52,11 +60,24 @@ export function ViewportCanvas({ modelUrl, modelId }: ViewportCanvasProps) {
           </div>
         )}
 
+        <Select
+          value={viewMode}
+          onValueChange={(value) => setViewMode(value as "solid" | "ghosted" | "wireframe")}
+        >
+          <SelectTrigger className="absolute top-2 right-2 z-10 cursor-pointer text-sm w-30 border-choras-primary text-choras-primary [&>svg]:stroke-choras-primary hover:bg-accent">
+            <SelectValue placeholder="View Mode" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="solid">Solid</SelectItem>
+            <SelectItem value="ghosted">Ghosted</SelectItem>
+            <SelectItem value="wireframe">Wireframe</SelectItem>
+          </SelectContent>
+        </Select>
         <Button
           onClick={toggleCameraType}
           variant="outline"
           size="sm"
-          className="absolute top-2 right-2 z-10 cursor-pointer hover:bg-accent"
+          className="absolute top-14 right-2 z-10 cursor-pointer hover:bg-accent"
         >
           <span className="hidden sm:inline">
             {cameraType === "perspective" ? "Perspective" : "Orthographic"}
@@ -119,11 +140,11 @@ export function ViewportCanvas({ modelUrl, modelId }: ViewportCanvasProps) {
             maxDistance={1000}
             zoomSpeed={0.5}
           />
-          <GizmoHelper alignment="top-right" margin={[60, 100]}>
+          <GizmoHelper alignment="top-right" margin={[60, 140]}>
             <GizmoViewport axisColors={["red", "green", "blue"]} labelColor="black" />
           </GizmoHelper>
 
-          {modelId && <ModelRenderer modelId={modelId} />}
+          {modelId && <ModelRenderer modelId={modelId} viewMode={viewMode} />}
           <SourceVisualization orbitControlsRef={orbitControlsRef} />
           <ReceiverVisualization orbitControlsRef={orbitControlsRef} />
         </Canvas>

--- a/src/pages/ResultPage.tsx
+++ b/src/pages/ResultPage.tsx
@@ -8,10 +8,31 @@ import { Breadcrumb } from "@/components/ui/breadcrumb";
 import { EditorNav } from "@/components/features/viewport/EditorNav";
 import { TrapezoidOutlineTab } from "@/components/features/results/TrapezoidOutlineTab";
 import { CompareResult } from "@/components/features/results/CompareResult";
+import { setActiveSimulation } from "@/store/simulationSlice";
+import { useEffect } from "react";
+import { useGetSimulationsByModelIdQuery } from "@/store/simulationApi";
+import { useDispatch } from "react-redux";
 
 export function ResultPage() {
+  const dispatch = useDispatch();
   const { modelId, simulationId } = useParams() as { modelId: string; simulationId: string };
   const { data: model } = useGetModelQuery(modelId);
+  const { data: simulations } = useGetSimulationsByModelIdQuery(+modelId);
+
+  // If no simulationId is provided, redirect to the first simulation
+  // Once the simulations are created, the effect will run again
+  useEffect(() => {
+    if (simulations && simulations.length > 0) {
+      // If simulationId is provided, find the active simulation and set it in the store
+      if (simulationId) {
+        const activeSimulation = simulations.find((sim) => sim.id === +simulationId);
+        if (activeSimulation) {
+          dispatch(setActiveSimulation(activeSimulation));
+          return;
+        }
+      }
+    }
+  }, [simulations, simulationId, modelId, dispatch]);
 
   return (
     <AppLayout

--- a/src/pages/ResultPage.tsx
+++ b/src/pages/ResultPage.tsx
@@ -1,14 +1,13 @@
 import { AppLayout } from "@/components/ui/app-layout";
-import { Link, useParams } from "react-router";
-import { Button } from "@/components/ui/button";
+import { useParams } from "react-router";
 import { ResultAuralizations } from "@/components/features/results/ResultAuralizations";
-import { DownloadResult } from "@/components/features/results/DownloadResult";
 import { ResultParameters } from "@/components/features/results/ResultParameters";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { useGetModelQuery } from "@/store/modelApi";
 import { Breadcrumb } from "@/components/ui/breadcrumb";
 import { EditorNav } from "@/components/features/viewport/EditorNav";
 import { TrapezoidOutlineTab } from "@/components/features/results/TrapezoidOutlineTab";
+import { CompareResult } from "@/components/features/results/CompareResult";
 
 export function ResultPage() {
   const { modelId, simulationId } = useParams() as { modelId: string; simulationId: string };
@@ -36,25 +35,7 @@ export function ResultPage() {
           />
         )
       }
-      sidebar={
-        <div className="h-full flex flex-col justify-end p-4 space-y-3">
-          <DownloadResult
-            mode="parameters"
-            triggerLabel="Download Parameters"
-            simulationId={+simulationId}
-          />
-          <DownloadResult mode="plots" triggerLabel="Download Plots" simulationId={+simulationId} />
-          <DownloadResult
-            mode="auralizations"
-            triggerLabel="Download Impulse Response"
-            simulationId={+simulationId}
-          />
-          <DownloadResult simulationId={+simulationId} />
-          <Button asChild variant="secondary" className="w-full">
-            <Link to={`/editor/${modelId}/${simulationId}`}>Exit Result</Link>
-          </Button>
-        </div>
-      }
+      sidebar={<CompareResult modelId={+modelId} />}
     >
       <EditorNav active="results" modelId={+modelId} simulationId={+simulationId} />
       <Tabs defaultValue="parameters" className="mt-8">

--- a/src/store/materialsApi.ts
+++ b/src/store/materialsApi.ts
@@ -12,7 +12,15 @@ export const materialsApi = createApi({
       query: () => "/materials",
       providesTags: [{ type: "Materials", id: "LIST" }],
     }),
+    createMaterial: build.mutation<Material, Omit<Material, "id" | "createdAt" | "updatedAt">>({
+      query: (newMaterial) => ({
+        url: "/materials",
+        method: "POST",
+        body: newMaterial,
+      }),
+      invalidatesTags: [{ type: "Materials", id: "LIST" }],
+    }),
   }),
 });
 
-export const { useGetMaterialsQuery } = materialsApi;
+export const { useGetMaterialsQuery, useCreateMaterialMutation } = materialsApi;

--- a/src/store/projectApi.ts
+++ b/src/store/projectApi.ts
@@ -1,5 +1,5 @@
 import { createApi, fetchBaseQuery } from "@reduxjs/toolkit/query/react";
-import type { Project } from "@/types/project";
+import type { Project, ProjectSimulation } from "@/types/project";
 
 // Define a service using a base URL and expected endpoints
 export const projectApi = createApi({
@@ -88,6 +88,11 @@ export const projectApi = createApi({
       // Invalidates all Project-type queries providing the `LIST` id - after all, depending of the sort order,
       invalidatesTags: [{ type: "Projects", id: "LIST" }],
     }),
+
+    // Get all simulation runs
+    getProjectsSimulations: build.query<ProjectSimulation[], void>({
+      query: () => `/projects/simulations`,
+    }),
   }),
 });
 
@@ -101,4 +106,5 @@ export const {
   useDeleteProjectMutation,
   useUpdateProjectsByGroupMutation,
   useDeleteProjectsByGroupMutation,
+  useGetProjectsSimulationsQuery,
 } = projectApi;

--- a/src/store/simulationApi.ts
+++ b/src/store/simulationApi.ts
@@ -67,4 +67,5 @@ export const {
   useGetSimulationByIdQuery,
   useUpdateSimulationMutation,
   useGetSimulationResultQuery,
+  useLazyGetSimulationResultQuery,
 } = simulationApi;

--- a/src/store/simulationSelector.ts
+++ b/src/store/simulationSelector.ts
@@ -42,16 +42,14 @@ export const selectCompareSimulationIds = createSelector(selectCompareResults, (
 );
 
 // Selector to create chart series data from compare results
-export const selectCompareResultsSeriesData = (parameter: keyof Parameters, modelId?: number) =>
+export const selectCompareResultsSeriesData = (parameter: keyof Parameters) =>
   createSelector(
     (state: RootState) => state.simulation.compareResults,
-    (state: RootState) =>
-      !modelId ? [] : simulationApi.endpoints.getSimulationsByModelId.select(modelId)(state)?.data,
     (state: RootState) => state,
-    (compareResults, simulations, state) => {
+    (compareResults, state) => {
       return compareResults
         .map((compareResult) => {
-          const { simulationId, sourceId, receiverId, color } = compareResult;
+          const { simulationId, sourceId, receiverId, color, modelId } = compareResult;
 
           // Skip if simulation or receiver is not selected
           if (!simulationId || !receiverId || !sourceId) {
@@ -67,8 +65,15 @@ export const selectCompareResultsSeriesData = (parameter: keyof Parameters, mode
             return null;
           }
 
+          // Get simulations for the modelId from RTK Query cache
+          const simulationsState =
+            simulationApi.endpoints.getSimulationsByModelId.select(modelId)(state);
+          const simulations = simulationsState?.data;
+
           // Get simulation name
-          const simulation = simulations?.find((sim) => sim.id === simulationId);
+          const simulation = simulations?.find(
+            (sim) => sim.id.toString() === simulationId.toString(),
+          );
           const simulationName = simulation?.name || `Simulation ${simulationId}`;
 
           // Find the result for the selected source and receiver

--- a/src/store/simulationSelector.ts
+++ b/src/store/simulationSelector.ts
@@ -1,5 +1,8 @@
 import { createSelector } from "@reduxjs/toolkit/react";
 import { simulationApi } from "./simulationApi";
+import { FREQUENCY_BANDS } from "@/constants";
+import { roundTo2 } from "@/helpers/number";
+import type { Parameters } from "@/types/simulation";
 
 import type { RootState } from "./index";
 import { selectModelIdsByProjectId } from "./projectSelector";
@@ -27,3 +30,67 @@ export const selectSimulationCountByProjectId = createSelector(
 
 // Selector to get the active simulation from the state
 export const selectActiveSimulation = (state: RootState) => state.simulation.activeSimulation;
+
+// Selector to get compare results from the state
+export const selectCompareResults = (state: RootState) => state.simulation.compareResults;
+
+// Selector to create chart series data from compare results
+export const selectCompareResultsSeriesData = (parameter: keyof Parameters, modelId?: number) =>
+  createSelector(
+    (state: RootState) => state.simulation.compareResults,
+    (state: RootState) =>
+      !modelId ? [] : simulationApi.endpoints.getSimulationsByModelId.select(modelId)(state)?.data,
+    (state: RootState) => state,
+    (compareResults, simulations, state) => {
+      return compareResults
+        .map((compareResult) => {
+          const { simulationId, sourceId, receiverId, color } = compareResult;
+
+          // Skip if simulation or receiver is not selected
+          if (!simulationId || !receiverId || !sourceId) {
+            return null;
+          }
+
+          // Get simulation result from RTK Query cache
+          const resultState =
+            simulationApi.endpoints.getSimulationResult.select(simulationId)(state);
+          const results = resultState?.data;
+
+          if (!results || results.length === 0) {
+            return null;
+          }
+
+          // Get simulation name
+          const simulation = simulations?.find((sim) => sim.id === simulationId);
+          const simulationName = simulation?.name || `Simulation ${simulationId}`;
+
+          // Find the result for the selected source and receiver
+          const result = results.find((res) => res.sourcePointId === sourceId);
+
+          if (!result) {
+            return null;
+          }
+
+          const response = result?.responses?.find((resp) => resp.pointId === receiverId);
+
+          if (!response) {
+            return null;
+          }
+
+          // Prepare series data
+          const data = FREQUENCY_BANDS.map((freq) => {
+            const paramValue = response.parameters[parameter];
+            const index = result.frequencies.indexOf(freq);
+            const value = paramValue[index];
+            return value ? roundTo2(value) : null;
+          });
+
+          return {
+            name: `${simulationName} - ${result.label} & ${response.label}`,
+            color,
+            data: data,
+          };
+        })
+        .filter((series) => series !== null);
+    },
+  );

--- a/src/store/simulationSelector.ts
+++ b/src/store/simulationSelector.ts
@@ -34,6 +34,13 @@ export const selectActiveSimulation = (state: RootState) => state.simulation.act
 // Selector to get compare results from the state
 export const selectCompareResults = (state: RootState) => state.simulation.compareResults;
 
+export const selectCompareSimulationIds = createSelector(selectCompareResults, (compareResults) =>
+  compareResults
+    .map((result) => result.simulationId)
+    .filter((id) => id !== null)
+    .map(Number),
+);
+
 // Selector to create chart series data from compare results
 export const selectCompareResultsSeriesData = (parameter: keyof Parameters, modelId?: number) =>
   createSelector(

--- a/src/store/simulationSlice.ts
+++ b/src/store/simulationSlice.ts
@@ -5,6 +5,7 @@ type SimulationState = {
   activeSimulation: Simulation | null;
   compareResults: {
     id: string;
+    modelId: number;
     simulationId: number | null;
     sourceId: string | null;
     receiverId: string | null;

--- a/src/store/simulationSlice.ts
+++ b/src/store/simulationSlice.ts
@@ -3,20 +3,53 @@ import { createSlice } from "@reduxjs/toolkit";
 
 type SimulationState = {
   activeSimulation: Simulation | null;
+  compareResults: {
+    id: string;
+    simulationId: number | null;
+    sourceId: string | null;
+    receiverId: string | null;
+    color: string;
+  }[];
 };
 
 const simulationSlice = createSlice({
   name: "simulation",
   initialState: {
     activeSimulation: null,
+    compareResults: [],
   } as SimulationState,
   reducers: {
     setActiveSimulation: (state, action) => {
       state.activeSimulation = action.payload;
     },
+    addCompareResult: (state, action) => {
+      state.compareResults.push(action.payload);
+    },
+    removeCompareResult: (state, action) => {
+      state.compareResults = state.compareResults.filter((result) => result.id !== action.payload);
+    },
+    updateCompareResult: (state, action) => {
+      const { id, field, value } = action.payload;
+      const index = state.compareResults.findIndex((r) => r.id === id);
+      if (index !== -1) {
+        state.compareResults[index] = {
+          ...state.compareResults[index],
+          [field]: value,
+        };
+      }
+    },
+    initializeCompareResults: (state, action) => {
+      state.compareResults = action.payload;
+    },
   },
 });
 
-export const { setActiveSimulation } = simulationSlice.actions;
+export const {
+  setActiveSimulation,
+  addCompareResult,
+  removeCompareResult,
+  updateCompareResult,
+  initializeCompareResults,
+} = simulationSlice.actions;
 
 export const simulationReducer = simulationSlice.reducer;

--- a/src/types/modelViewport.ts
+++ b/src/types/modelViewport.ts
@@ -4,6 +4,7 @@ export interface ModelViewerProps {
 
 export interface ModelRendererProps {
   modelId: number;
+  viewMode: "solid" | "ghosted" | "wireframe";
 }
 
 export interface ViewportCanvasProps {

--- a/src/types/project.ts
+++ b/src/types/project.ts
@@ -1,4 +1,5 @@
 import type { Model } from "./model";
+import type { SimulationRun } from "./simulation";
 
 export interface Project {
   createdAt: string;
@@ -13,4 +14,14 @@ export interface Project {
 export interface GroupProject {
   group: string;
   projects: Array<Project>;
+}
+
+export interface ProjectSimulation {
+  group: string;
+  modelCreatedAt: string;
+  modelId: number;
+  modelName: string;
+  projectId: number;
+  projectName: string;
+  simulations: SimulationRun[];
 }


### PR DESCRIPTION
This pull request introduces several new features and enhancements focused on improving the simulation results comparison workflow, model selection, and overall user experience. The most notable changes include the addition of new material components, a comprehensive model selection dialog, and a revamped comparison results panel with enhanced result handling and UI interaction. The changes also include bug fixes and improvements to data handling and lazy loading for simulation results.

**New Features and Components:**

* Added a `ChooseModel` component that provides a modal dialog for selecting models by group and project, streamlining the process of choosing models for comparison.
* Implemented a `CompareResult` component to manage and display a list of comparison results, allowing users to add new results and initialize with the active simulation.
* Developed a `CompareResultItem` component with improved simulation selection, source/receiver selection, model switching, and download functionality for simulation results.

**Enhancements to Data Handling and UI:**

* Updated lazy loading for simulation results and improved the result parameters selector for better data management.
* Refactored simulation result handling to use selectors, enhancing state management and component integration.

**Bug Fixes and Miscellaneous Improvements:**

* Fixed issues with simulation polling rate, results tab visibility, simulation button validation, and improved text orientation for user experience.
* Updated the download functionality to support multiple simulation IDs, enabling batch downloads in comparison scenarios. [[1]](diffhunk://#diff-dd2f2ea1713b1db8bfe17ed791db38b6b85ea4bc00d75c480cd4e2cefd496008L25-R39) [[2]](diffhunk://#diff-dd2f2ea1713b1db8bfe17ed791db38b6b85ea4bc00d75c480cd4e2cefd496008L80-R82)
* Bumped the application version to `0.0.19` in `package.json` and updated the changelog to reflect all recent changes and fixes. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L4-R4) [[2]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR5-R35)