### PR TITLE
Build Docker containers on main only and add unique tag names

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -2,12 +2,11 @@ name: Build and Push Docker Image (Linux only)
 
 on:
   push:
-    branches: [ dev ]
+    branches: [ main ]
   workflow_dispatch:  # Allow manual trigger
 
 env:
   IMAGE_NAME: silvinwillemsen/choras-frontend
-  TAG: latest
 
 jobs:
   build:
@@ -31,6 +30,19 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
+      - name: Get short git SHA
+        id: gitvars
+        run: echo "short_sha=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
+
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.IMAGE_NAME }}
+          tags: |
+            type=raw,value=${{ steps.gitvars.outputs.short_sha }}
+            type=raw,value=latest,enable={{is_default_branch}}
+
       - name: Build and Push Docker image
         uses: docker/build-push-action@v6
         with:
@@ -38,9 +50,8 @@ jobs:
           file: Dockerfile
           platforms: linux/amd64  # Add linux/arm64 if you want multi-arch
           push: true
-          tags: |
-            ${{ env.IMAGE_NAME }}:${{ env.TAG }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
 
       - name: Show pushed images
-        run: docker buildx imagetools inspect ${{ env.IMAGE_NAME }}:${{ env.TAG }}
- 
+        run: docker buildx imagetools inspect ${IMAGE_NAME}:${{ steps.gitvars.outputs.short_sha }}

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,9 +1,8 @@
-name: Build and Push Docker Image (Linux only)
+name: Publish Docker Image on Main
 
 on:
   push:
     branches: [ main ]
-  workflow_dispatch:  # Allow manual trigger
 
 env:
   IMAGE_NAME: silvinwillemsen/choras-frontend
@@ -40,7 +39,7 @@ jobs:
         with:
           images: ${{ env.IMAGE_NAME }}
           tags: |
-            type=raw,value=${{ steps.gitvars.outputs.short_sha }}
+            type=raw,value=stable-${{ steps.gitvars.outputs.short_sha }}
             type=raw,value=latest,enable={{is_default_branch}}
 
       - name: Build and Push Docker image
@@ -54,4 +53,4 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
 
       - name: Show pushed images
-        run: docker buildx imagetools inspect ${IMAGE_NAME}:${{ steps.gitvars.outputs.short_sha }}
+        run: docker buildx imagetools inspect ${IMAGE_NAME}:stable-${{ steps.gitvars.outputs.short_sha }}

--- a/.github/workflows/docker-pr-build.yml
+++ b/.github/workflows/docker-pr-build.yml
@@ -33,7 +33,7 @@ jobs:
         with:
           images: ${{ env.IMAGE_NAME }}
           tags: |
-            type=raw,value=${{ steps.gitvars.outputs.short_sha }}
+            type=raw,value=stable-${{ steps.gitvars.outputs.short_sha }}
             type=raw,value=latest,enable={{is_default_branch}}
 
       - name: Build Docker image (no push)

--- a/.github/workflows/docker-pr-build.yml
+++ b/.github/workflows/docker-pr-build.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     types: [ opened, synchronize, reopened ]
 
+env:
+  IMAGE_NAME: silvinwillemsen/choras-frontend
+
 jobs:
   build-pr-image:
     runs-on: ubuntu-latest
@@ -20,6 +23,19 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
+      - name: Get short git SHA
+        id: gitvars
+        run: echo "short_sha=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
+
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.IMAGE_NAME }}
+          tags: |
+            type=raw,value=${{ steps.gitvars.outputs.short_sha }}
+            type=raw,value=latest,enable={{is_default_branch}}
+
       - name: Build Docker image (no push)
         uses: docker/build-push-action@v6
         with:
@@ -27,3 +43,5 @@ jobs:
           file: Dockerfile
           platforms: linux/amd64
           push: false
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/docker-pr-build.yml
+++ b/.github/workflows/docker-pr-build.yml
@@ -1,0 +1,29 @@
+name: Build Docker Image for PRs
+
+on:
+  pull_request:
+    types: [ opened, synchronize, reopened ]
+
+jobs:
+  build-pr-image:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Set up QEMU (for multi-arch builds)
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build Docker image (no push)
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile
+          platforms: linux/amd64
+          push: false


### PR DESCRIPTION
- Building on main only should be more stable than dev
- To not overwrite older versions, the containers are tagged based on the git commit id