### PR TITLE
BUG: Replace the unit for the center time with ms

### DIFF
--- a/src/components/features/results/ResultParameters.tsx
+++ b/src/components/features/results/ResultParameters.tsx
@@ -31,7 +31,7 @@ const getParameterLabel = (key: keyof Parameters) => {
     spl_t0_freq: "dB",
     t20: "s",
     t30: "s",
-    ts: "s",
+    ts: "ms",
   } as const;
 
   return `${key.toUpperCase()} (${units[key] || ""})`;


### PR DESCRIPTION
Using ms instead of seconds is favorable, since most the parameter falls in the 2 digit ms range for most RIRs ]
Methods already return ms instead of seconds.