### PR TITLE
BUG: Fix the error messages in the results tabs

### DIFF
--- a/src/components/features/results/ResultParameters.tsx
+++ b/src/components/features/results/ResultParameters.tsx
@@ -50,7 +50,7 @@ export function ResultParameters({ simulationId }: ResultParametersProps) {
   if (error) {
     return (
       <Alert variant="destructive">
-        <AlertDescription>Failed to load impulse response</AlertDescription>
+        <AlertDescription>Failed to load room acoustic parameters</AlertDescription>
       </Alert>
     );
   }

--- a/src/components/features/results/ResultPlots.tsx
+++ b/src/components/features/results/ResultPlots.tsx
@@ -44,7 +44,7 @@ export function ResultPlots({ simulationId }: ResultParametersProps) {
   if (error) {
     return (
       <Alert variant="destructive">
-        <AlertDescription>Failed to load impulse response</AlertDescription>
+        <AlertDescription>Failed to load plot data</AlertDescription>
       </Alert>
     );
   }


### PR DESCRIPTION
The error message was copy pasted from the impulse response. Replaced the error messages for room acoustic parameters and plots with the correct ones.