### PR TITLE
Feat: implement lazy loading for material dropdown and group material assignment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [0.0.81](https://github.com/dhimashary/CHORAS/compare/v0.0.80...v0.0.81) (2026-07-14)
+
+### Features
+
+- add support for virtualized rendering and geometry selection enhancements ([728a849](https://github.com/dhimashary/CHORAS/commit/728a849d4b511671063eec86fd93657d0804ead5))
+- enhance geometry selection and material assignment functionality ([da26903](https://github.com/dhimashary/CHORAS/commit/da26903ce449fd1e69dbc20739e62135d814eff4))
+- implement lazy loading for material dropdown and group surface management ([c8960b3](https://github.com/dhimashary/CHORAS/commit/c8960b378dad71e9a3c1a957aea0cbb014f97f7b))
+- integrate mesh registry for improved selection and highlighting of current model meshes ([918f720](https://github.com/dhimashary/CHORAS/commit/918f7203c3060ca0e4177b9f0da9398c055f238e))
+
+### Bug Fixes
+
+- Add correct tab title and logo ([#179](https://github.com/dhimashary/CHORAS/issues/179)) ([3c909d1](https://github.com/dhimashary/CHORAS/commit/3c909d1f8faa7458936d23663b6b16467aed66f1)), closes [#180](https://github.com/dhimashary/CHORAS/issues/180)
+
 ### [0.0.80](https://github.com/ajatdarojat45/choras-frontend/compare/v0.0.79...v0.0.80) (2026-06-17)
 
 ### Features

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "@react-three/fiber": "^9.3.0",
         "@reduxjs/toolkit": "^2.9.0",
         "@tailwindcss/vite": "^4.1.13",
+        "@tanstack/react-virtual": "^3.14.6",
         "@types/jszip": "^3.4.0",
         "@types/three": "^0.180.0",
         "@wavesurfer/react": "^1.0.11",
@@ -2902,6 +2903,33 @@
       },
       "peerDependencies": {
         "vite": "^5.2.0 || ^6 || ^7"
+      }
+    },
+    "node_modules/@tanstack/react-virtual": {
+      "version": "3.14.6",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-virtual/-/react-virtual-3.14.6.tgz",
+      "integrity": "sha512-4+Uq8m0/gzO4kMCHUEpTtGX1RnONK0C+g88b2ltwPMWUBiaVarBuWKoPJaz7gj1cKCVRAdyu+U8GcKhwCc2beA==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/virtual-core": "3.17.4"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@tanstack/virtual-core": {
+      "version": "3.17.4",
+      "resolved": "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.17.4.tgz",
+      "integrity": "sha512-nGm5KteqxasUdThLc2izl6dHUqLv0LQj7Nuyo5gYalTPf/U8a9ermvsl7reT+6ioBW1l8WfpP/mcU338nLXpqw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
       }
     },
     "node_modules/@tweenjs/tween.js": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "app",
-  "version": "0.0.80",
+  "version": "0.0.81",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "app",
-      "version": "0.0.80",
+      "version": "0.0.81",
       "dependencies": {
         "@hookform/resolvers": "^5.2.2",
         "@monaco-editor/react": "^4.7.0",

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "@react-three/fiber": "^9.3.0",
     "@reduxjs/toolkit": "^2.9.0",
     "@tailwindcss/vite": "^4.1.13",
+    "@tanstack/react-virtual": "^3.14.6",
     "@types/jszip": "^3.4.0",
     "@types/three": "^0.180.0",
     "@wavesurfer/react": "^1.0.11",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "app",
   "private": true,
-  "version": "0.0.80",
+  "version": "0.0.81",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/components/features/simulationSettings/SurfacesTab.tsx
+++ b/src/components/features/simulationSettings/SurfacesTab.tsx
@@ -11,7 +11,9 @@ import * as THREE from "three";
 import type { RootState } from "@/store";
 import {
   assignMaterial,
+  assignMaterials,
   removeMaterialAssignment,
+  removeMaterialAssignments,
   clearAllAssignments,
   setAssignments,
 } from "@/store/materialAssignmentSlice";
@@ -94,6 +96,8 @@ export function SurfacesTab() {
   const [hiddenSurfaces, setHiddenSurfaces] = useState<Set<string>>(new Set());
   const scrollContainerRef = useRef<HTMLDivElement>(null);
   const {
+    selectedGeometry,
+    selectedGeometries,
     selectGeometry,
     addHighlightedMesh,
     addHighlightedMeshes,
@@ -118,9 +122,6 @@ export function SurfacesTab() {
   const activeSimulation = useSelector((state: RootState) => state.simulation.activeSimulation);
   const currentModelId = useSelector((state: RootState) => state.model.currentModelId);
   const highlightedElement = useSelector((state: RootState) => state.tab.highlightedElement);
-  const { selectedGeometry, selectedGeometries } = useSelector(
-    (state: RootState) => state.geometrySelection,
-  );
   const { data: simulation, error: simulationError } = useGetSimulationByIdQuery(
     activeSimulation?.id ?? 0,
     {
@@ -283,13 +284,13 @@ export function SurfacesTab() {
 
       surfaces.forEach((surface) => {
         const surfaceKey = surface.id;
-        dispatch(assignMaterial({ meshId: surfaceKey, materialId: numMaterialId }));
         newAssignments[surfaceKey] = numMaterialId;
 
         if (surface.mesh) {
           setMeshBaseColor(surface.mesh, absorptionColor);
         }
       });
+      dispatch(assignMaterials({ meshIds: surfaces.map((s) => s.id), materialId: numMaterialId }));
       updatedAssignments = { ...materialAssignments, ...newAssignments };
     }
 
@@ -306,12 +307,12 @@ export function SurfacesTab() {
 
     if (materialId === "default") {
       groupSurfaces.forEach((surface) => {
-        dispatch(removeMaterialAssignment(surface.id));
         delete updatedAssignments[surface.id];
         if (surface.mesh) {
           setMeshBaseColor(surface.mesh, 0xffffff);
         }
       });
+      dispatch(removeMaterialAssignments(groupSurfaces.map((s) => s.id)));
     } else {
       const numMaterialId = parseInt(materialId);
       const material = materialById.get(numMaterialId);
@@ -321,12 +322,14 @@ export function SurfacesTab() {
       const absorptionColor = getAbsorptionColor(avgAbsorption);
 
       groupSurfaces.forEach((surface) => {
-        dispatch(assignMaterial({ meshId: surface.id, materialId: numMaterialId }));
         updatedAssignments[surface.id] = numMaterialId;
         if (surface.mesh) {
           setMeshBaseColor(surface.mesh, absorptionColor);
         }
       });
+      dispatch(
+        assignMaterials({ meshIds: groupSurfaces.map((s) => s.id), materialId: numMaterialId }),
+      );
     }
 
     updateSimulationData(updatedAssignments);
@@ -604,15 +607,16 @@ export function SurfacesTab() {
     (surface: SurfaceInfo) => {
       // Restore/deselect every currently highlighted geometry (e.g. all
       // surfaces of an expanded group) so a plain click keeps only the clicked
-      // surface highlighted and clears the rest.
-      Object.values(selectedGeometries).forEach((geo) => {
-        removeHighlightedMesh(geo.mesh);
-        restoreOriginalColor(geo.mesh);
-      });
+      // surface highlighted and clears the rest. Restoring mesh colors is a
+      // cheap direct mutation; the Redux highlight removal is batched into a
+      // single dispatch to avoid a store update per surface.
+      const uuidsToClear = new Set(Object.keys(selectedGeometries));
+      Object.values(selectedGeometries).forEach((geo) => restoreOriginalColor(geo.mesh));
       if (selectedGeometry?.mesh) {
-        removeHighlightedMesh(selectedGeometry.mesh);
+        uuidsToClear.add(selectedGeometry.mesh.uuid);
         restoreOriginalColor(selectedGeometry.mesh);
       }
+      removeHighlightedMeshes(Array.from(uuidsToClear));
 
       // Highlight and select new mesh
       const payload = {
@@ -634,7 +638,7 @@ export function SurfacesTab() {
       highlightMesh,
       HIGHLIGHT_COLOR,
       addHighlightedMesh,
-      removeHighlightedMesh,
+      removeHighlightedMeshes,
       restoreOriginalColor,
       clearSelectedGeometries,
       addSelectedGeometry,
@@ -694,15 +698,17 @@ export function SurfacesTab() {
     if (materialId === "default") {
       const numMaterialId = parseInt(materialId);
       const newAssignments: Record<string, number> = {};
+      const assignedIds: string[] = [];
 
       surfaces.forEach((surface) => {
         if (selectedGeometries[surface.mesh.uuid]) {
           const surfaceKey = surface.id;
-          dispatch(assignMaterial({ meshId: surfaceKey, materialId: numMaterialId }));
+          assignedIds.push(surfaceKey);
           newAssignments[surfaceKey] = numMaterialId;
           setMeshBaseColor(surface.mesh, 0xffffff);
         }
       });
+      dispatch(assignMaterials({ meshIds: assignedIds, materialId: numMaterialId }));
 
       updatedAssignments = { ...materialAssignments, ...newAssignments };
     } else {
@@ -713,14 +719,16 @@ export function SurfacesTab() {
         : 0;
       const absorptionColor = getAbsorptionColor(avgAbsorption);
 
+      const assignedIds: string[] = [];
       surfaces.forEach((surface) => {
         if (selectedGeometries[surface.mesh.uuid]) {
           const surfaceKey = surface.id;
-          dispatch(assignMaterial({ meshId: surfaceKey, materialId: numMaterialId }));
+          assignedIds.push(surfaceKey);
           newAssignments[surfaceKey] = numMaterialId;
           setMeshBaseColor(surface.mesh, absorptionColor);
         }
       });
+      dispatch(assignMaterials({ meshIds: assignedIds, materialId: numMaterialId }));
 
       updatedAssignments = { ...materialAssignments, ...newAssignments };
     }

--- a/src/components/features/simulationSettings/SurfacesTab.tsx
+++ b/src/components/features/simulationSettings/SurfacesTab.tsx
@@ -1,4 +1,5 @@
-import { useState, useEffect, useCallback, useRef, useMemo, Fragment } from "react";
+import { useState, useEffect, useCallback, useRef, useMemo } from "react";
+import { useVirtualizer } from "@tanstack/react-virtual";
 import { useSurfaces } from "@/hooks/useSurfaces";
 import { useGetMaterialsQuery } from "@/store/materialsApi";
 import { useGetSimulationByIdQuery, useUpdateSimulationMutation } from "@/store/simulationApi";
@@ -91,13 +92,17 @@ export function SurfacesTab() {
   const surfaces = useSurfaces();
   const [showIndividualAssignments, setShowIndividualAssignments] = useState(false);
   const [hiddenSurfaces, setHiddenSurfaces] = useState<Set<string>>(new Set());
-  const selectedSurfaceRowRef = useRef<HTMLTableRowElement>(null);
+  const scrollContainerRef = useRef<HTMLDivElement>(null);
   const {
     selectGeometry,
     addHighlightedMesh,
+    addHighlightedMeshes,
     removeHighlightedMesh,
+    removeHighlightedMeshes,
     addSelectedGeometry,
+    addSelectedGeometries,
     removeSelectedGeometry,
+    removeSelectedGeometries,
     clearSelectedGeometries,
   } = useGeometrySelection();
   const { highlightMesh, restoreOriginalColor, setMeshBaseColor, HIGHLIGHT_COLOR } =
@@ -208,7 +213,7 @@ export function SurfacesTab() {
       return;
     }
 
-    const surface = surfaces.find((s) => s.id === surfaceKey);
+    const surface = surfaceById.get(surfaceKey);
 
     // If multiple surfaces selected and current surface is one of them, use bulk assign
     const isMultipleSelected =
@@ -238,7 +243,7 @@ export function SurfacesTab() {
       updatedAssignments = { ...materialAssignments, [surfaceKey]: numMaterialId };
 
       if (surface?.mesh) {
-        const material = materials.find((m) => m.id === numMaterialId);
+        const material = materialById.get(numMaterialId);
         if (material?.absorptionCoefficients) {
           const avgAbsorption = calculateAverageAbsorption(material.absorptionCoefficients);
           const absorptionColor = getAbsorptionColor(avgAbsorption);
@@ -257,7 +262,7 @@ export function SurfacesTab() {
     }
 
     let updatedAssignments: Record<string, number>;
-    const material = materials.find((m) => m.id === parseInt(materialId));
+    const material = materialById.get(parseInt(materialId));
 
     if (materialId === "default") {
       dispatch(clearAllAssignments());
@@ -309,7 +314,7 @@ export function SurfacesTab() {
       });
     } else {
       const numMaterialId = parseInt(materialId);
-      const material = materials.find((m) => m.id === numMaterialId);
+      const material = materialById.get(numMaterialId);
       const avgAbsorption = material?.absorptionCoefficients
         ? calculateAverageAbsorption(material.absorptionCoefficients)
         : 0;
@@ -329,7 +334,7 @@ export function SurfacesTab() {
 
   const getMaterialName = (materialId?: number) => {
     if (!materialId) return "Default";
-    const material = materials.find((m) => m.id === materialId);
+    const material = materialById.get(materialId);
     return material?.name || "Unknown Material";
   };
 
@@ -341,18 +346,11 @@ export function SurfacesTab() {
     return Number.isNaN(id) ? "None" : getMaterialName(id);
   };
 
-  const isMaterialsMixed = () => {
+  const isMaterialsMixed = useMemo(() => {
     if (surfaces.length === 0) return false;
-
-    const allMaterials = surfaces.map((surface) => {
-      const surfaceKey = surface.id;
-      return materialAssignments[surfaceKey];
-    });
-
-    const uniqueMaterials = new Set(allMaterials);
-
+    const uniqueMaterials = new Set(surfaces.map((surface) => materialAssignments[surface.id]));
     return uniqueMaterials.size > 1;
-  };
+  }, [surfaces, materialAssignments]);
 
   const getDisplayName = (surface: SurfaceInfo, index: number) => {
     if (surface.name && surface.name !== `Surface ${surface.meshId}`) {
@@ -361,17 +359,14 @@ export function SurfacesTab() {
     return `Surface [${index + 1}]`;
   };
 
-  const getAssignAllValue = () => {
+  const getAssignAllValue = useMemo(() => {
     if (surfaces.length === 0) return "default";
 
-    if (isMaterialsMixed()) {
+    if (isMaterialsMixed) {
       return "mixed";
     }
 
-    const assignedMaterials = surfaces.map((surface) => {
-      const surfaceKey = surface.id;
-      return materialAssignments[surfaceKey];
-    });
+    const assignedMaterials = surfaces.map((surface) => materialAssignments[surface.id]);
 
     const firstMaterial = assignedMaterials[0];
     const allSame = assignedMaterials.every((materialId) => materialId === firstMaterial);
@@ -381,7 +376,7 @@ export function SurfacesTab() {
     }
 
     return "default";
-  };
+  }, [surfaces, materialAssignments, isMaterialsMixed]);
 
   // Map each surface id to its global index so display names stay stable
   // regardless of how surfaces are grouped in the sidebar.
@@ -408,25 +403,95 @@ export function SurfacesTab() {
       .sort((a, b) => a.name.localeCompare(b.name));
   }, [surfaces]);
 
+  // O(1) lookup maps to avoid repeated linear scans over materials/surfaces.
+  const materialById = useMemo(() => {
+    const map = new Map<number, (typeof materials)[number]>();
+    materials.forEach((material) => map.set(material.id, material));
+    return map;
+  }, [materials]);
+
+  const surfaceById = useMemo(() => {
+    const map = new Map<string, SurfaceInfo>();
+    surfaces.forEach((surface) => map.set(surface.id, surface));
+    return map;
+  }, [surfaces]);
+
+  const surfaceByUuid = useMemo(() => {
+    const map = new Map<string, SurfaceInfo>();
+    surfaces.forEach((surface) => map.set(surface.mesh.uuid, surface));
+    return map;
+  }, [surfaces]);
+
+  type SurfaceGroup = { name: string; surfaces: SurfaceInfo[] };
+  type FlatRow =
+    | { kind: "assign-all"; key: string }
+    | { kind: "group"; key: string; group: SurfaceGroup }
+    | { kind: "surface"; key: string; group: SurfaceGroup; surface: SurfaceInfo; index: number };
+
+  // Flatten the visible tree (assign-all row + group headers + expanded surface
+  // rows) into a single list so it can be virtualized. Only rows for expanded
+  // groups are included here; highlighting in the 3D viewport is handled
+  // separately in `toggleGroup` and covers every surface regardless of what is
+  // rendered.
+  const flatRows = useMemo(() => {
+    const rows: FlatRow[] = [{ kind: "assign-all", key: "__assign_all__" }];
+    if (showIndividualAssignments) {
+      surfaceGroups.forEach((group) => {
+        rows.push({ kind: "group", key: `group:${group.name}`, group });
+        if (expandedGroups.has(group.name)) {
+          group.surfaces.forEach((surface) => {
+            rows.push({
+              kind: "surface",
+              key: `surface:${surface.id}`,
+              group,
+              surface,
+              index: surfaceIndexById.get(surface.id) ?? 0,
+            });
+          });
+        }
+      });
+    }
+    return rows;
+  }, [surfaceGroups, expandedGroups, showIndividualAssignments, surfaceIndexById]);
+
+  // Estimated starting height per row; the real height of each rendered row is
+  // measured dynamically via `measureElement`, so rows may be taller (e.g. when
+  // content wraps) without clipping or overlapping.
+  const ROW_HEIGHT = 48;
+  const rowVirtualizer = useVirtualizer({
+    count: flatRows.length,
+    getScrollElement: () => scrollContainerRef.current,
+    estimateSize: () => ROW_HEIGHT,
+    measureElement: (element) => element.getBoundingClientRect().height,
+    overscan: 0,
+    getItemKey: (index) => flatRows[index].key,
+  });
+
   const highlightGroupSurfaces = (groupSurfaces: SurfaceInfo[]) => {
+    // Mutate mesh colors directly (cheap, non-Redux) per surface, but batch the
+    // Redux selection/highlight updates into a single dispatch each so opening a
+    // large group does not fire thousands of store updates.
     groupSurfaces.forEach((surface) => {
       highlightMesh(surface.mesh, HIGHLIGHT_COLOR);
-      addHighlightedMesh(surface.mesh);
-      addSelectedGeometry({
+    });
+    addHighlightedMeshes(groupSurfaces.map((surface) => surface.mesh));
+    addSelectedGeometries(
+      groupSurfaces.map((surface) => ({
         mesh: surface.mesh,
         faceIndex: 0,
         point: new THREE.Vector3(),
         materialId: surface.id,
-      });
-    });
+      })),
+    );
   };
 
   const unhighlightGroupSurfaces = (groupSurfaces: SurfaceInfo[]) => {
     groupSurfaces.forEach((surface) => {
-      removeHighlightedMesh(surface.mesh);
       restoreOriginalColor(surface.mesh);
-      removeSelectedGeometry(surface.mesh.uuid);
     });
+    const uuids = groupSurfaces.map((surface) => surface.mesh.uuid);
+    removeHighlightedMeshes(uuids);
+    removeSelectedGeometries(uuids);
   };
 
   const toggleGroup = (group: { name: string; surfaces: SurfaceInfo[] }) => {
@@ -499,18 +564,11 @@ export function SurfacesTab() {
     }, 500);
   };
 
-  const getSelectedSurfaceId = (): string | null => {
+  const selectedSurfaceId = useMemo(() => {
     if (!selectedGeometry?.mesh) return null;
-
-    const selectedMesh = selectedGeometry.mesh;
-    const matchedSurface = surfaces.find(
-      (surface) => surface.mesh === selectedMesh || surface.mesh.uuid === selectedMesh.uuid,
-    );
-
-    return matchedSurface?.id || null;
-  };
-
-  const selectedSurfaceId = getSelectedSurfaceId();
+    const matched = surfaceByUuid.get(selectedGeometry.mesh.uuid);
+    return matched?.id ?? null;
+  }, [selectedGeometry, surfaceByUuid]);
 
   useEffect(() => {
     if (!selectedSurfaceId) return;
@@ -520,25 +578,37 @@ export function SurfacesTab() {
     }
 
     // Ensure the group containing the selected surface is expanded so its row
-    // is rendered and can be highlighted / scrolled into view.
+    // exists in the flattened list and can be scrolled into view.
     const selectedSurface = surfaces.find((surface) => surface.id === selectedSurfaceId);
     const groupName = selectedSurface?.rhinoMaterialName || "Ungrouped";
     setExpandedGroups((prev) => (prev.has(groupName) ? prev : new Set(prev).add(groupName)));
+  }, [selectedSurfaceId, showIndividualAssignments, surfaces]);
 
-    if (
-      showIndividualAssignments &&
-      expandedGroups.has(groupName) &&
-      selectedSurfaceRowRef.current
-    ) {
-      setTimeout(() => {
-        selectedSurfaceRowRef.current?.scrollIntoView({ behavior: "smooth", block: "nearest" });
-      }, 50);
-    }
-  }, [selectedSurfaceId, showIndividualAssignments, expandedGroups, surfaces]);
+  // Scroll the selected surface into view once it is present in the flattened,
+  // virtualized list.
+  useEffect(() => {
+    if (!selectedSurfaceId) return;
+
+    const flatIndex = flatRows.findIndex(
+      (row) => row.kind === "surface" && row.surface.id === selectedSurfaceId,
+    );
+    if (flatIndex < 0) return;
+
+    const timer = setTimeout(() => {
+      rowVirtualizer.scrollToIndex(flatIndex, { align: "center" });
+    }, 50);
+    return () => clearTimeout(timer);
+  }, [selectedSurfaceId, flatRows, rowVirtualizer]);
 
   const handleSelectSurface = useCallback(
     (surface: SurfaceInfo) => {
-      // Restore previous mesh if it exists
+      // Restore/deselect every currently highlighted geometry (e.g. all
+      // surfaces of an expanded group) so a plain click keeps only the clicked
+      // surface highlighted and clears the rest.
+      Object.values(selectedGeometries).forEach((geo) => {
+        removeHighlightedMesh(geo.mesh);
+        restoreOriginalColor(geo.mesh);
+      });
       if (selectedGeometry?.mesh) {
         removeHighlightedMesh(selectedGeometry.mesh);
         restoreOriginalColor(selectedGeometry.mesh);
@@ -558,6 +628,7 @@ export function SurfacesTab() {
       addSelectedGeometry(payload);
     },
     [
+      selectedGeometries,
       selectedGeometry,
       selectGeometry,
       highlightMesh,
@@ -565,6 +636,8 @@ export function SurfacesTab() {
       addHighlightedMesh,
       removeHighlightedMesh,
       restoreOriginalColor,
+      clearSelectedGeometries,
+      addSelectedGeometry,
     ],
   );
 
@@ -616,7 +689,7 @@ export function SurfacesTab() {
 
     setBulkMaterialId(materialId);
     let updatedAssignments: Record<string, number>;
-    const material = materials.find((m) => m.id === parseInt(materialId));
+    const material = materialById.get(parseInt(materialId));
 
     if (materialId === "default") {
       const numMaterialId = parseInt(materialId);
@@ -724,7 +797,22 @@ export function SurfacesTab() {
             }`}
           >
             <div className="relative">
+              {/* Fixed column header (kept outside the scroll area so the
+                  virtualized body can start at scroll offset 0). */}
+              <div className="flex items-center border-b border-choras-gray pr-4">
+                <div className="w-36 px-3 py-2 text-left text-xs font-medium text-gray-300 uppercase tracking-wider">
+                  Surface
+                </div>
+                <div className="flex-1 px-3 py-2 text-left text-xs font-medium text-gray-300 uppercase tracking-wider">
+                  Material
+                </div>
+              </div>
+
+              {/* Virtualized, scrollable body. Only rows within the viewport are
+                  mounted; group highlighting in the 3D viewport still covers
+                  every surface in the group (see toggleGroup). */}
               <div
+                ref={scrollContainerRef}
                 className="
                 max-h-120 overflow-y-auto pr-4
                 scrollbar-thin
@@ -733,236 +821,220 @@ export function SurfacesTab() {
                 scrollbar-thumb-rounded-full
               "
               >
-                <table className="w-full table-fixed">
-                  <thead>
-                    <tr>
-                      <th className="px-3 py-2 text-left text-xs font-medium text-gray-300 uppercase tracking-wider w-36">
-                        Surface
-                      </th>
-                      <th className="px-3 py-2 text-left text-xs font-medium text-gray-300 uppercase tracking-wider">
-                        Material
-                      </th>
-                    </tr>
-                  </thead>
-                  <tbody>
-                    <tr className="border-b border-choras-gray">
-                      <td className="px-3 py-2 text-sm">
-                        <button
-                          onClick={() => setShowIndividualAssignments(!showIndividualAssignments)}
-                          className="flex items-center gap-2 font-medium text-white hover:text-gray-300 transition-colors"
-                        >
-                          <span
-                            className={`transform transition-transform ${showIndividualAssignments ? "rotate-90" : "rotate-0"}`}
+                <TooltipProvider>
+                  <div
+                    style={{
+                      height: `${rowVirtualizer.getTotalSize()}px`,
+                      width: "100%",
+                      position: "relative",
+                    }}
+                  >
+                    {rowVirtualizer.getVirtualItems().map((virtualRow) => {
+                      const row = flatRows[virtualRow.index];
+                      const rowStyle = {
+                        position: "absolute" as const,
+                        top: 0,
+                        left: 0,
+                        width: "100%",
+                        transform: `translateY(${virtualRow.start}px)`,
+                      };
+
+                      if (row.kind === "assign-all") {
+                        return (
+                          <div
+                            key={virtualRow.key}
+                            data-index={virtualRow.index}
+                            ref={rowVirtualizer.measureElement}
+                            style={rowStyle}
+                            className="flex items-center border-b border-choras-gray"
                           >
-                            <ChevronRight size={16} />
-                          </span>
-                          Assign all
-                        </button>
-                      </td>
-                      <td className="px-3 py-2">
-                        <Select
-                          value={getAssignAllValue()}
-                          onValueChange={handleAssignAllMaterials}
-                        >
-                          <SelectTrigger
-                            size="sm"
-                            className="w-full bg-choras-dark border-choras-gray text-white [&>span]:truncate [&>span]:block [&>span]:max-w-full [&>svg]:text-choras-gray"
+                            <div className="w-36 px-3 py-2 text-sm">
+                              <button
+                                onClick={() =>
+                                  setShowIndividualAssignments(!showIndividualAssignments)
+                                }
+                                className="flex items-center gap-2 font-medium text-white hover:text-gray-300 transition-colors"
+                              >
+                                <span
+                                  className={`transform transition-transform ${showIndividualAssignments ? "rotate-90" : "rotate-0"}`}
+                                >
+                                  <ChevronRight size={16} />
+                                </span>
+                                Assign all
+                              </button>
+                            </div>
+                            <div
+                              className="flex-1 min-w-0 px-3 py-2"
+                              onClick={(e) => e.stopPropagation()}
+                            >
+                              <Select
+                                value={getAssignAllValue}
+                                onValueChange={handleAssignAllMaterials}
+                              >
+                                <SelectTrigger
+                                  size="sm"
+                                  className="w-full bg-choras-dark border-choras-gray text-white [&>span]:truncate [&>span]:block [&>span]:max-w-full [&>svg]:text-choras-gray"
+                                >
+                                  {isMaterialsMixed ? (
+                                    <div className="flex items-center text-white">Mixed</div>
+                                  ) : (
+                                    <SelectValue placeholder="Select material for all surfaces" />
+                                  )}
+                                </SelectTrigger>
+                                <SelectContent className="bg-choras-dark border-choras-gray">
+                                  <SelectItem value="default" className="text-white">
+                                    None
+                                  </SelectItem>
+                                  <SelectItem
+                                    value="mixed"
+                                    className="text-gray-400"
+                                    disabled
+                                    hidden
+                                  >
+                                    Mixed
+                                  </SelectItem>
+                                  {materialSelectOptions}
+                                </SelectContent>
+                              </Select>
+                            </div>
+                          </div>
+                        );
+                      }
+
+                      if (row.kind === "group") {
+                        const group = row.group;
+                        const isGroupExpanded = expandedGroups.has(group.name);
+                        return (
+                          <div
+                            key={virtualRow.key}
+                            data-index={virtualRow.index}
+                            ref={rowVirtualizer.measureElement}
+                            style={rowStyle}
+                            className="flex items-center border-t border-gray-700 bg-choras-dark/40"
                           >
-                            {isMaterialsMixed() ? (
-                              <div className="flex items-center text-white">Mixed</div>
-                            ) : (
-                              <SelectValue placeholder="Select material for all surfaces" />
-                            )}
-                          </SelectTrigger>
-                          <SelectContent className="bg-choras-dark border-choras-gray">
-                            <SelectItem value="default" className="text-white">
-                              None
-                            </SelectItem>
-                            <SelectItem value="mixed" className="text-gray-400" disabled hidden>
-                              Mixed
-                            </SelectItem>
-                            {materialsLoading ? (
-                              <SelectItem value="loading" disabled className="text-gray-400">
-                                Loading materials...
-                              </SelectItem>
-                            ) : materialsError ? (
-                              <SelectItem value="error" disabled className="text-red-400">
-                                Error loading materials
-                              </SelectItem>
-                            ) : (
-                              <TooltipProvider>
-                                {materials.map((material) => (
-                                  <Tooltip key={material.id} delayDuration={300}>
-                                    <TooltipTrigger asChild>
-                                      <SelectItem
-                                        value={material.id.toString()}
-                                        className="text-white"
-                                      >
-                                        <span className="truncate block" title={material.name}>
-                                          {material.name}
-                                        </span>
-                                      </SelectItem>
-                                    </TooltipTrigger>
-                                    <TooltipContent
-                                      side="right"
-                                      className="p-3 bg-choras-dark border-choras-primary"
-                                    >
-                                      <div className="text-sm mb-2 font-medium text-white">
-                                        {material.name}
-                                      </div>
-                                      <AbsorptionCoefficientChart
-                                        coefficients={material.absorptionCoefficients}
-                                        size="md"
-                                      />
-                                    </TooltipContent>
-                                  </Tooltip>
-                                ))}
-                                <hr className="border-t border-gray-700 my-1" />
-                                <SelectItem value="open-library" className="text-choras-primary">
-                                  Open material library
-                                </SelectItem>
-                              </TooltipProvider>
-                            )}
-                          </SelectContent>
-                        </Select>
-                      </td>
-                    </tr>
-
-                    <TooltipProvider>
-                      {showIndividualAssignments &&
-                        surfaceGroups.map((group) => {
-                          const isGroupExpanded = expandedGroups.has(group.name);
-
-                          return (
-                            <Fragment key={group.name}>
-                              {/* Group header row: assign a material to the whole group */}
-                              <tr className="border-t border-gray-700 bg-choras-dark/40">
-                                <td className="px-3 py-2 text-sm">
-                                  <button
-                                    onClick={() => toggleGroup(group)}
-                                    className="flex items-center gap-2 font-medium text-white hover:text-gray-300 transition-colors w-full text-left"
+                            <div className="w-36 min-w-0 px-3 py-2 text-sm">
+                              <button
+                                onClick={() => toggleGroup(group)}
+                                className="flex items-center gap-2 font-medium text-white hover:text-gray-300 transition-colors w-full text-left"
+                              >
+                                <span
+                                  className={`transform transition-transform flex-shrink-0 ${isGroupExpanded ? "rotate-90" : "rotate-0"}`}
+                                >
+                                  <ChevronRight size={16} />
+                                </span>
+                                <span className="truncate" title={group.name}>
+                                  {group.name}
+                                </span>
+                                <span className="text-xs text-gray-400 flex-shrink-0">
+                                  ({group.surfaces.length})
+                                </span>
+                              </button>
+                            </div>
+                            <div
+                              className="flex-1 min-w-0 px-3 py-2"
+                              onClick={(e) => e.stopPropagation()}
+                            >
+                              <Select
+                                value={getGroupAssignValue(group.surfaces)}
+                                onValueChange={(value) =>
+                                  handleAssignGroupMaterials(group.surfaces, value)
+                                }
+                              >
+                                <SelectTrigger
+                                  size="sm"
+                                  className="w-full bg-choras-dark border-choras-gray text-white [&>span]:truncate [&>span]:block [&>span]:max-w-full [&>svg]:text-choras-gray"
+                                >
+                                  {isGroupMaterialsMixed(group.surfaces) ? (
+                                    <div className="flex items-center text-white">Mixed</div>
+                                  ) : (
+                                    <SelectValue placeholder="Select material for group" />
+                                  )}
+                                </SelectTrigger>
+                                <SelectContent className="bg-choras-dark border-choras-gray">
+                                  <SelectItem value="default" className="text-white">
+                                    None
+                                  </SelectItem>
+                                  <SelectItem
+                                    value="mixed"
+                                    className="text-gray-400"
+                                    disabled
+                                    hidden
                                   >
-                                    <span
-                                      className={`transform transition-transform flex-shrink-0 ${isGroupExpanded ? "rotate-90" : "rotate-0"}`}
-                                    >
-                                      <ChevronRight size={16} />
-                                    </span>
-                                    <span className="truncate" title={group.name}>
-                                      {group.name}
-                                    </span>
-                                    <span className="text-xs text-gray-400 flex-shrink-0">
-                                      ({group.surfaces.length})
-                                    </span>
-                                  </button>
-                                </td>
-                                <td className="px-3 py-2" onClick={(e) => e.stopPropagation()}>
-                                  <Select
-                                    value={getGroupAssignValue(group.surfaces)}
-                                    onValueChange={(value) =>
-                                      handleAssignGroupMaterials(group.surfaces, value)
-                                    }
-                                  >
-                                    <SelectTrigger
-                                      size="sm"
-                                      className="w-full bg-choras-dark border-choras-gray text-white [&>span]:truncate [&>span]:block [&>span]:max-w-full [&>svg]:text-choras-gray"
-                                    >
-                                      {isGroupMaterialsMixed(group.surfaces) ? (
-                                        <div className="flex items-center text-white">Mixed</div>
-                                      ) : (
-                                        <SelectValue placeholder="Select material for group" />
-                                      )}
-                                    </SelectTrigger>
-                                    <SelectContent className="bg-choras-dark border-choras-gray">
-                                      <SelectItem value="default" className="text-white">
-                                        None
-                                      </SelectItem>
-                                      <SelectItem
-                                        value="mixed"
-                                        className="text-gray-400"
-                                        disabled
-                                        hidden
-                                      >
-                                        Mixed
-                                      </SelectItem>
-                                      {materialSelectOptions}
-                                    </SelectContent>
-                                  </Select>
-                                </td>
-                              </tr>
+                                    Mixed
+                                  </SelectItem>
+                                  {materialSelectOptions}
+                                </SelectContent>
+                              </Select>
+                            </div>
+                          </div>
+                        );
+                      }
 
-                              {/* Individual surfaces within the group */}
-                              {isGroupExpanded &&
-                                group.surfaces.map((surface) => {
-                                  const surfaceKey = surface.id;
-                                  const assignedMaterialId = materialAssignments[surfaceKey];
-                                  const isSelected = selectedSurfaceId === surface.id;
-                                  const index = surfaceIndexById.get(surface.id) ?? 0;
-
-                                  return (
-                                    <tr
-                                      key={surface.id}
-                                      ref={isSelected ? selectedSurfaceRowRef : null}
-                                      onClick={(e) => {
-                                        if (e.ctrlKey || e.metaKey) {
-                                          handleSelectMultipleSurfaces(surface);
-                                        } else {
-                                          handleSelectSurface(surface);
-                                        }
-                                      }}
-                                      className={`border-t border-gray-700 transition-colors duration-200 cursor-pointer ${
-                                        selectedGeometries[surface.mesh.uuid]
-                                          ? "bg-choras-primary/20 hover:bg-choras-primary/30"
-                                          : "hover:bg-choras-dark/90"
-                                      }`}
-                                    >
-                                      <td className="px-3 py-2 text-sm w-1/3">
-                                        <div className="flex items-center gap-2 pl-6">
-                                          <div
-                                            onClick={(e) => {
-                                              e.stopPropagation();
-                                              toggleSurfaceVisibility(surfaceKey);
-                                            }}
-                                            className="cursor-pointer text-white hover:text-gray-300 transition-colors flex-shrink-0"
-                                          >
-                                            {hiddenSurfaces.has(surfaceKey) ? (
-                                              <EyeOff className="h-4 w-4" />
-                                            ) : (
-                                              <Eye className="h-4 w-4" />
-                                            )}
-                                          </div>
-                                          <div className="font-medium truncate">
-                                            {getDisplayName(surface, index)}
-                                          </div>
-                                        </div>
-                                      </td>
-                                      <td
-                                        className="px-3 py-2 w-1/3"
-                                        onClick={(e) => e.stopPropagation()}
-                                      >
-                                        <LazyMaterialSelect
-                                          value={assignedMaterialId?.toString() || "default"}
-                                          label={materialLabelForValue(
-                                            assignedMaterialId?.toString() || "default",
-                                          )}
-                                          onValueChange={(value) =>
-                                            handleMaterialAssignment(surfaceKey, value)
-                                          }
-                                        >
-                                          <SelectItem value="default" className="text-white">
-                                            None
-                                          </SelectItem>
-                                          {materialSelectOptions}
-                                        </LazyMaterialSelect>
-                                      </td>
-                                    </tr>
-                                  );
-                                })}
-                            </Fragment>
-                          );
-                        })}
-                    </TooltipProvider>
-                  </tbody>
-                </table>
+                      // row.kind === "surface"
+                      const surface = row.surface;
+                      const surfaceKey = surface.id;
+                      const assignedMaterialId = materialAssignments[surfaceKey];
+                      return (
+                        <div
+                          key={virtualRow.key}
+                          data-index={virtualRow.index}
+                          ref={rowVirtualizer.measureElement}
+                          style={rowStyle}
+                          onClick={(e) => {
+                            if (e.ctrlKey || e.metaKey) {
+                              handleSelectMultipleSurfaces(surface);
+                            } else {
+                              handleSelectSurface(surface);
+                            }
+                          }}
+                          className={`flex items-center border-t border-gray-700 transition-colors duration-200 cursor-pointer ${
+                            selectedGeometries[surface.mesh.uuid]
+                              ? "bg-choras-primary/20 hover:bg-choras-primary/30"
+                              : "hover:bg-choras-dark/90"
+                          }`}
+                        >
+                          <div className="w-36 min-w-0 px-3 py-2 text-sm">
+                            <div className="flex items-center gap-2 pl-6">
+                              <div
+                                onClick={(e) => {
+                                  e.stopPropagation();
+                                  toggleSurfaceVisibility(surfaceKey);
+                                }}
+                                className="cursor-pointer text-white hover:text-gray-300 transition-colors flex-shrink-0"
+                              >
+                                {hiddenSurfaces.has(surfaceKey) ? (
+                                  <EyeOff className="h-4 w-4" />
+                                ) : (
+                                  <Eye className="h-4 w-4" />
+                                )}
+                              </div>
+                              <div className="font-medium truncate">
+                                {getDisplayName(surface, row.index)}
+                              </div>
+                            </div>
+                          </div>
+                          <div
+                            className="flex-1 min-w-0 px-3 py-2"
+                            onClick={(e) => e.stopPropagation()}
+                          >
+                            <LazyMaterialSelect
+                              value={assignedMaterialId?.toString() || "default"}
+                              label={materialLabelForValue(
+                                assignedMaterialId?.toString() || "default",
+                              )}
+                              onValueChange={(value) => handleMaterialAssignment(surfaceKey, value)}
+                            >
+                              <SelectItem value="default" className="text-white">
+                                None
+                              </SelectItem>
+                              {materialSelectOptions}
+                            </LazyMaterialSelect>
+                          </div>
+                        </div>
+                      );
+                    })}
+                  </div>
+                </TooltipProvider>
               </div>
             </div>
           </div>

--- a/src/components/features/simulationSettings/SurfacesTab.tsx
+++ b/src/components/features/simulationSettings/SurfacesTab.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback, useRef, useMemo } from "react";
+import { useState, useEffect, useCallback, useRef, useMemo, Fragment } from "react";
 import { useSurfaces } from "@/hooks/useSurfaces";
 import { useGetMaterialsQuery } from "@/store/materialsApi";
 import { useGetSimulationByIdQuery, useUpdateSimulationMutation } from "@/store/simulationApi";
@@ -25,11 +25,66 @@ import {
 } from "@/components/ui/select";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import type { SurfaceInfo } from "@/types/material";
-import { ChevronRight, Eye, EyeOff, Plus } from "lucide-react";
+import { ChevronDown, ChevronRight, Eye, EyeOff, Plus } from "lucide-react";
 import { SurfaceMaterialList } from "./SurfaceMaterialList";
 import { AbsorptionCoefficientChart } from "./AbsorptionCoefficientChart";
 import { Button } from "@/components/ui/button";
 import { FullSettingJsonEditor } from "./FullSettingJsonEditor";
+
+/**
+ * A material dropdown that only mounts the (relatively heavy) Radix `Select`
+ * when the user interacts with it. Before that it renders a cheap button that
+ * mimics the trigger. This keeps expanding a large surface list fast, since we
+ * mount N lightweight buttons instead of N Radix Selects up front.
+ */
+function LazyMaterialSelect({
+  value,
+  label,
+  onValueChange,
+  children,
+}: {
+  value: string;
+  label: React.ReactNode;
+  onValueChange: (value: string) => void;
+  children: React.ReactNode;
+}) {
+  const [open, setOpen] = useState(false);
+
+  if (!open) {
+    return (
+      <button
+        type="button"
+        onClick={(e) => {
+          e.stopPropagation();
+          setOpen(true);
+        }}
+        className="flex h-8 w-full items-center justify-between gap-2 rounded-md border border-choras-gray bg-choras-dark px-3 py-1 text-sm text-white"
+      >
+        <span className="truncate">{label}</span>
+        <ChevronDown className="h-4 w-4 shrink-0 text-choras-gray" />
+      </button>
+    );
+  }
+
+  return (
+    <Select
+      defaultOpen
+      value={value}
+      onValueChange={onValueChange}
+      onOpenChange={(isOpen) => {
+        if (!isOpen) setOpen(false);
+      }}
+    >
+      <SelectTrigger
+        size="sm"
+        className="w-full bg-choras-dark border-choras-gray text-white [&>span]:truncate [&>span]:block [&>span]:max-w-full [&>svg]:text-choras-gray"
+      >
+        <span className="truncate">{label}</span>
+      </SelectTrigger>
+      <SelectContent className="bg-choras-dark border-choras-gray">{children}</SelectContent>
+    </Select>
+  );
+}
 
 export function SurfacesTab() {
   const dispatch = useDispatch();
@@ -71,6 +126,7 @@ export function SurfacesTab() {
   const [openMaterialLibrary, setOpenMaterialLibrary] = useState(false);
   const [openCreateMaterialDialog, setOpenCreateMaterialDialog] = useState(false);
   const [bulkMaterialId, setBulkMaterialId] = useState<string>("");
+  const [expandedGroups, setExpandedGroups] = useState<Set<string>>(new Set());
 
   useEffect(() => {
     if (simulation?.layerIdByMaterialId) {
@@ -235,10 +291,54 @@ export function SurfacesTab() {
     updateSimulationData(updatedAssignments);
   };
 
+  const handleAssignGroupMaterials = async (groupSurfaces: SurfaceInfo[], materialId: string) => {
+    if (materialId === "open-library") {
+      setOpenMaterialLibrary(true);
+      return;
+    }
+
+    const updatedAssignments: Record<string, number> = { ...materialAssignments };
+
+    if (materialId === "default") {
+      groupSurfaces.forEach((surface) => {
+        dispatch(removeMaterialAssignment(surface.id));
+        delete updatedAssignments[surface.id];
+        if (surface.mesh) {
+          setMeshBaseColor(surface.mesh, 0xffffff);
+        }
+      });
+    } else {
+      const numMaterialId = parseInt(materialId);
+      const material = materials.find((m) => m.id === numMaterialId);
+      const avgAbsorption = material?.absorptionCoefficients
+        ? calculateAverageAbsorption(material.absorptionCoefficients)
+        : 0;
+      const absorptionColor = getAbsorptionColor(avgAbsorption);
+
+      groupSurfaces.forEach((surface) => {
+        dispatch(assignMaterial({ meshId: surface.id, materialId: numMaterialId }));
+        updatedAssignments[surface.id] = numMaterialId;
+        if (surface.mesh) {
+          setMeshBaseColor(surface.mesh, absorptionColor);
+        }
+      });
+    }
+
+    updateSimulationData(updatedAssignments);
+  };
+
   const getMaterialName = (materialId?: number) => {
     if (!materialId) return "Default";
     const material = materials.find((m) => m.id === materialId);
     return material?.name || "Unknown Material";
+  };
+
+  // Resolve the label shown on a (lazy) material dropdown for a given value.
+  const materialLabelForValue = (value: string) => {
+    if (value === "mixed") return "Mixed";
+    if (value === "default") return "None";
+    const id = parseInt(value);
+    return Number.isNaN(id) ? "None" : getMaterialName(id);
   };
 
   const isMaterialsMixed = () => {
@@ -283,6 +383,95 @@ export function SurfacesTab() {
     return "default";
   };
 
+  // Map each surface id to its global index so display names stay stable
+  // regardless of how surfaces are grouped in the sidebar.
+  const surfaceIndexById = useMemo(() => {
+    const map = new Map<string, number>();
+    surfaces.forEach((surface, index) => map.set(surface.id, index));
+    return map;
+  }, [surfaces]);
+
+  // Group surfaces by their Rhino material name (from the original `usemtl`).
+  const surfaceGroups = useMemo(() => {
+    const groups = new Map<string, SurfaceInfo[]>();
+    surfaces.forEach((surface) => {
+      const groupName = surface.rhinoMaterialName || "Ungrouped";
+      const existing = groups.get(groupName);
+      if (existing) {
+        existing.push(surface);
+      } else {
+        groups.set(groupName, [surface]);
+      }
+    });
+    return Array.from(groups.entries())
+      .map(([name, groupSurfaces]) => ({ name, surfaces: groupSurfaces }))
+      .sort((a, b) => a.name.localeCompare(b.name));
+  }, [surfaces]);
+
+  const highlightGroupSurfaces = (groupSurfaces: SurfaceInfo[]) => {
+    groupSurfaces.forEach((surface) => {
+      highlightMesh(surface.mesh, HIGHLIGHT_COLOR);
+      addHighlightedMesh(surface.mesh);
+      addSelectedGeometry({
+        mesh: surface.mesh,
+        faceIndex: 0,
+        point: new THREE.Vector3(),
+        materialId: surface.id,
+      });
+    });
+  };
+
+  const unhighlightGroupSurfaces = (groupSurfaces: SurfaceInfo[]) => {
+    groupSurfaces.forEach((surface) => {
+      removeHighlightedMesh(surface.mesh);
+      restoreOriginalColor(surface.mesh);
+      removeSelectedGeometry(surface.mesh.uuid);
+    });
+  };
+
+  const toggleGroup = (group: { name: string; surfaces: SurfaceInfo[] }) => {
+    const isExpanded = expandedGroups.has(group.name);
+
+    if (isExpanded) {
+      // Collapsing: remove the group's highlight/selection. If the currently
+      // focused surface belongs to this group, deselect it first so the
+      // auto-expand effect does not immediately re-open the group.
+      unhighlightGroupSurfaces(group.surfaces);
+      if (
+        selectedGeometry?.mesh &&
+        group.surfaces.some((surface) => surface.mesh.uuid === selectedGeometry.mesh.uuid)
+      ) {
+        selectGeometry(null);
+      }
+      setExpandedGroups((prev) => {
+        const next = new Set(prev);
+        next.delete(group.name);
+        return next;
+      });
+    } else {
+      // Expanding: highlight every surface in the group in the viewport.
+      highlightGroupSurfaces(group.surfaces);
+      setExpandedGroups((prev) => {
+        const next = new Set(prev);
+        next.add(group.name);
+        return next;
+      });
+    }
+  };
+
+  const isGroupMaterialsMixed = (groupSurfaces: SurfaceInfo[]) => {
+    if (groupSurfaces.length === 0) return false;
+    const unique = new Set(groupSurfaces.map((surface) => materialAssignments[surface.id]));
+    return unique.size > 1;
+  };
+
+  const getGroupAssignValue = (groupSurfaces: SurfaceInfo[]) => {
+    if (groupSurfaces.length === 0) return "default";
+    if (isGroupMaterialsMixed(groupSurfaces)) return "mixed";
+    const first = materialAssignments[groupSurfaces[0].id];
+    return first !== undefined ? first.toString() : "default";
+  };
+
   const toggleSurfaceVisibility = (surfaceId: string) => {
     setHiddenSurfaces((prev) => {
       const newSet = new Set(prev);
@@ -324,16 +513,28 @@ export function SurfacesTab() {
   const selectedSurfaceId = getSelectedSurfaceId();
 
   useEffect(() => {
-    if (selectedSurfaceId && !showIndividualAssignments) {
+    if (!selectedSurfaceId) return;
+
+    if (!showIndividualAssignments) {
       setShowIndividualAssignments(true);
     }
 
-    if (selectedSurfaceId && showIndividualAssignments && selectedSurfaceRowRef.current) {
+    // Ensure the group containing the selected surface is expanded so its row
+    // is rendered and can be highlighted / scrolled into view.
+    const selectedSurface = surfaces.find((surface) => surface.id === selectedSurfaceId);
+    const groupName = selectedSurface?.rhinoMaterialName || "Ungrouped";
+    setExpandedGroups((prev) => (prev.has(groupName) ? prev : new Set(prev).add(groupName)));
+
+    if (
+      showIndividualAssignments &&
+      expandedGroups.has(groupName) &&
+      selectedSurfaceRowRef.current
+    ) {
       setTimeout(() => {
         selectedSurfaceRowRef.current?.scrollIntoView({ behavior: "smooth", block: "nearest" });
       }, 50);
     }
-  }, [selectedSurfaceId, showIndividualAssignments]);
+  }, [selectedSurfaceId, showIndividualAssignments, expandedGroups, surfaces]);
 
   const handleSelectSurface = useCallback(
     (surface: SurfaceInfo) => {
@@ -629,72 +830,134 @@ export function SurfacesTab() {
 
                     <TooltipProvider>
                       {showIndividualAssignments &&
-                        surfaces.map((surface, index) => {
-                          const surfaceKey = surface.id;
-                          const assignedMaterialId = materialAssignments[surfaceKey];
-                          const isSelected = selectedSurfaceId === surface.id;
+                        surfaceGroups.map((group) => {
+                          const isGroupExpanded = expandedGroups.has(group.name);
 
                           return (
-                            <tr
-                              key={surface.id}
-                              ref={isSelected ? selectedSurfaceRowRef : null}
-                              onClick={(e) => {
-                                if (e.ctrlKey || e.metaKey) {
-                                  handleSelectMultipleSurfaces(surface);
-                                } else {
-                                  handleSelectSurface(surface);
-                                }
-                              }}
-                              className={`border-t border-gray-700 transition-colors duration-200 cursor-pointer ${
-                                selectedGeometries[surface.mesh.uuid]
-                                  ? "bg-choras-primary/20 hover:bg-choras-primary/30"
-                                  : "hover:bg-choras-dark/90"
-                              }`}
-                            >
-                              <td className="px-3 py-2 text-sm w-1/3">
-                                <div className="flex items-center gap-2">
-                                  <div
-                                    onClick={(e) => {
-                                      e.stopPropagation();
-                                      toggleSurfaceVisibility(surfaceKey);
-                                    }}
-                                    className="cursor-pointer text-white hover:text-gray-300 transition-colors flex-shrink-0"
+                            <Fragment key={group.name}>
+                              {/* Group header row: assign a material to the whole group */}
+                              <tr className="border-t border-gray-700 bg-choras-dark/40">
+                                <td className="px-3 py-2 text-sm">
+                                  <button
+                                    onClick={() => toggleGroup(group)}
+                                    className="flex items-center gap-2 font-medium text-white hover:text-gray-300 transition-colors w-full text-left"
                                   >
-                                    {hiddenSurfaces.has(surfaceKey) ? (
-                                      <EyeOff className="h-4 w-4" />
-                                    ) : (
-                                      <Eye className="h-4 w-4" />
-                                    )}
-                                  </div>
-                                  <div className="font-medium truncate">
-                                    {getDisplayName(surface, index)}
-                                  </div>
-                                </div>
-                              </td>
-                              <td className="px-3 py-2 w-1/3" onClick={(e) => e.stopPropagation()}>
-                                <Select
-                                  value={assignedMaterialId?.toString() || "default"}
-                                  onValueChange={(value) =>
-                                    handleMaterialAssignment(surfaceKey, value)
-                                  }
-                                >
-                                  <SelectTrigger
-                                    size="sm"
-                                    className="w-full bg-choras-dark border-choras-gray text-white [&>span]:truncate [&>span]:block [&>span]:max-w-full [&>svg]:text-choras-gray"
+                                    <span
+                                      className={`transform transition-transform flex-shrink-0 ${isGroupExpanded ? "rotate-90" : "rotate-0"}`}
+                                    >
+                                      <ChevronRight size={16} />
+                                    </span>
+                                    <span className="truncate" title={group.name}>
+                                      {group.name}
+                                    </span>
+                                    <span className="text-xs text-gray-400 flex-shrink-0">
+                                      ({group.surfaces.length})
+                                    </span>
+                                  </button>
+                                </td>
+                                <td className="px-3 py-2" onClick={(e) => e.stopPropagation()}>
+                                  <Select
+                                    value={getGroupAssignValue(group.surfaces)}
+                                    onValueChange={(value) =>
+                                      handleAssignGroupMaterials(group.surfaces, value)
+                                    }
                                   >
-                                    <SelectValue
-                                      placeholder={getMaterialName(assignedMaterialId)}
-                                    />
-                                  </SelectTrigger>
-                                  <SelectContent className="bg-choras-dark border-choras-gray">
-                                    <SelectItem value="default" className="text-white">
-                                      None
-                                    </SelectItem>
-                                    {materialSelectOptions}
-                                  </SelectContent>
-                                </Select>
-                              </td>
-                            </tr>
+                                    <SelectTrigger
+                                      size="sm"
+                                      className="w-full bg-choras-dark border-choras-gray text-white [&>span]:truncate [&>span]:block [&>span]:max-w-full [&>svg]:text-choras-gray"
+                                    >
+                                      {isGroupMaterialsMixed(group.surfaces) ? (
+                                        <div className="flex items-center text-white">Mixed</div>
+                                      ) : (
+                                        <SelectValue placeholder="Select material for group" />
+                                      )}
+                                    </SelectTrigger>
+                                    <SelectContent className="bg-choras-dark border-choras-gray">
+                                      <SelectItem value="default" className="text-white">
+                                        None
+                                      </SelectItem>
+                                      <SelectItem
+                                        value="mixed"
+                                        className="text-gray-400"
+                                        disabled
+                                        hidden
+                                      >
+                                        Mixed
+                                      </SelectItem>
+                                      {materialSelectOptions}
+                                    </SelectContent>
+                                  </Select>
+                                </td>
+                              </tr>
+
+                              {/* Individual surfaces within the group */}
+                              {isGroupExpanded &&
+                                group.surfaces.map((surface) => {
+                                  const surfaceKey = surface.id;
+                                  const assignedMaterialId = materialAssignments[surfaceKey];
+                                  const isSelected = selectedSurfaceId === surface.id;
+                                  const index = surfaceIndexById.get(surface.id) ?? 0;
+
+                                  return (
+                                    <tr
+                                      key={surface.id}
+                                      ref={isSelected ? selectedSurfaceRowRef : null}
+                                      onClick={(e) => {
+                                        if (e.ctrlKey || e.metaKey) {
+                                          handleSelectMultipleSurfaces(surface);
+                                        } else {
+                                          handleSelectSurface(surface);
+                                        }
+                                      }}
+                                      className={`border-t border-gray-700 transition-colors duration-200 cursor-pointer ${
+                                        selectedGeometries[surface.mesh.uuid]
+                                          ? "bg-choras-primary/20 hover:bg-choras-primary/30"
+                                          : "hover:bg-choras-dark/90"
+                                      }`}
+                                    >
+                                      <td className="px-3 py-2 text-sm w-1/3">
+                                        <div className="flex items-center gap-2 pl-6">
+                                          <div
+                                            onClick={(e) => {
+                                              e.stopPropagation();
+                                              toggleSurfaceVisibility(surfaceKey);
+                                            }}
+                                            className="cursor-pointer text-white hover:text-gray-300 transition-colors flex-shrink-0"
+                                          >
+                                            {hiddenSurfaces.has(surfaceKey) ? (
+                                              <EyeOff className="h-4 w-4" />
+                                            ) : (
+                                              <Eye className="h-4 w-4" />
+                                            )}
+                                          </div>
+                                          <div className="font-medium truncate">
+                                            {getDisplayName(surface, index)}
+                                          </div>
+                                        </div>
+                                      </td>
+                                      <td
+                                        className="px-3 py-2 w-1/3"
+                                        onClick={(e) => e.stopPropagation()}
+                                      >
+                                        <LazyMaterialSelect
+                                          value={assignedMaterialId?.toString() || "default"}
+                                          label={materialLabelForValue(
+                                            assignedMaterialId?.toString() || "default",
+                                          )}
+                                          onValueChange={(value) =>
+                                            handleMaterialAssignment(surfaceKey, value)
+                                          }
+                                        >
+                                          <SelectItem value="default" className="text-white">
+                                            None
+                                          </SelectItem>
+                                          {materialSelectOptions}
+                                        </LazyMaterialSelect>
+                                      </td>
+                                    </tr>
+                                  );
+                                })}
+                            </Fragment>
                           );
                         })}
                     </TooltipProvider>

--- a/src/components/features/viewport/ModelRenderer.tsx
+++ b/src/components/features/viewport/ModelRenderer.tsx
@@ -30,6 +30,7 @@ export function ModelRenderer({ modelId, viewMode }: ModelRendererProps) {
     highlightedMeshes,
     addHighlightedMesh,
     removeHighlightedMesh,
+    removeHighlightedMeshes,
     selectedGeometries,
     addSelectedGeometry,
     removeSelectedGeometry,
@@ -219,11 +220,9 @@ export function ModelRenderer({ modelId, viewMode }: ModelRendererProps) {
         const mesh = intersection.object as THREE.Mesh;
 
         if (mesh.visible === false) {
-          Object.keys(selectedGeometries).forEach((uuid) => {
-            const geo = selectedGeometries[uuid];
-            removeHighlightedMesh(geo.mesh);
-            restoreOriginalColor(geo.mesh);
-          });
+          const uuidsToClear = Object.keys(selectedGeometries);
+          uuidsToClear.forEach((uuid) => restoreOriginalColor(selectedGeometries[uuid].mesh));
+          removeHighlightedMeshes(uuidsToClear);
           clearSelection();
           return;
         }
@@ -261,11 +260,9 @@ export function ModelRenderer({ modelId, viewMode }: ModelRendererProps) {
           }
         } else {
           // Single select mode - clear previous and select new
-          Object.keys(selectedGeometries).forEach((uuid) => {
-            const geo = selectedGeometries[uuid];
-            removeHighlightedMesh(geo.mesh);
-            restoreOriginalColor(geo.mesh);
-          });
+          const uuidsToClear = Object.keys(selectedGeometries);
+          uuidsToClear.forEach((uuid) => restoreOriginalColor(selectedGeometries[uuid].mesh));
+          removeHighlightedMeshes(uuidsToClear);
           clearSelection();
 
           highlightMesh(mesh, HIGHLIGHT_COLOR);
@@ -285,17 +282,16 @@ export function ModelRenderer({ modelId, viewMode }: ModelRendererProps) {
           });
         }
       } else {
-        Object.keys(selectedGeometries).forEach((uuid) => {
-          const geo = selectedGeometries[uuid];
-          removeHighlightedMesh(geo.mesh);
-          restoreOriginalColor(geo.mesh);
-        });
+        const uuidsToClear = Object.keys(selectedGeometries);
+        uuidsToClear.forEach((uuid) => restoreOriginalColor(selectedGeometries[uuid].mesh));
+        removeHighlightedMeshes(uuidsToClear);
         clearSelection();
       }
     },
     [
       selectedGeometries,
       removeHighlightedMesh,
+      removeHighlightedMeshes,
       restoreOriginalColor,
       highlightMesh,
       addHighlightedMesh,

--- a/src/components/features/viewport/ModelRenderer.tsx
+++ b/src/components/features/viewport/ModelRenderer.tsx
@@ -5,6 +5,7 @@ import { useModelLoader } from "@/hooks/useModelLoader";
 import { useGeometrySelection } from "@/hooks/useGeometrySelection";
 import { useMeshHighlight } from "@/hooks/useMeshHighlight";
 import { createEdgeOutlineForObject3D } from "@/helpers/layerProcessor";
+import { meshRegistry } from "@/helpers/meshRegistry";
 import { selectSource, selectReceiver } from "@/store/sourceReceiverSlice";
 import { setActiveTab } from "@/store/tabSlice";
 import type { RootState } from "@/store";
@@ -92,18 +93,27 @@ export function ModelRenderer({ modelId, viewMode }: ModelRendererProps) {
     if (modelData?.object3D && currentModelId === modelId) {
       applyViewMode(modelData.object3D);
 
+      // The mesh registry only needs the current model's meshes; drop any left
+      // over from a previously loaded model, then register this model's meshes
+      // so selection/highlight UUIDs resolve back to live objects.
+      meshRegistry.clear();
+
       modelData.object3D.traverse((child) => {
-        if (child instanceof THREE.Mesh && child.material) {
-          const materials = Array.isArray(child.material) ? child.material : [child.material];
-          materials.forEach((material) => {
-            if (
-              material instanceof THREE.MeshStandardMaterial ||
-              material instanceof THREE.MeshBasicMaterial
-            ) {
-              material.color.setHex(0xffffff);
-              material.needsUpdate = true;
-            }
-          });
+        if (child instanceof THREE.Mesh) {
+          meshRegistry.register(child);
+
+          if (child.material) {
+            const materials = Array.isArray(child.material) ? child.material : [child.material];
+            materials.forEach((material) => {
+              if (
+                material instanceof THREE.MeshStandardMaterial ||
+                material instanceof THREE.MeshBasicMaterial
+              ) {
+                material.color.setHex(0xffffff);
+                material.needsUpdate = true;
+              }
+            });
+          }
         }
       });
 

--- a/src/helpers/meshRegistry.ts
+++ b/src/helpers/meshRegistry.ts
@@ -1,0 +1,35 @@
+import * as THREE from "three";
+
+/**
+ * Module-level registry that maps mesh UUIDs to their live `THREE.Mesh`
+ * instances. Redux only stores serializable data (UUIDs + plain values), while
+ * the actual (non-serializable) mesh objects live here. Consumers resolve a
+ * mesh from a UUID via `meshRegistry.get(uuid)`.
+ */
+const registry = new Map<string, THREE.Mesh>();
+
+export const meshRegistry = {
+  register(mesh: THREE.Mesh): void {
+    registry.set(mesh.uuid, mesh);
+  },
+
+  registerMany(meshes: THREE.Mesh[]): void {
+    meshes.forEach((mesh) => registry.set(mesh.uuid, mesh));
+  },
+
+  get(uuid: string): THREE.Mesh | undefined {
+    return registry.get(uuid);
+  },
+
+  has(uuid: string): boolean {
+    return registry.has(uuid);
+  },
+
+  unregister(uuid: string): void {
+    registry.delete(uuid);
+  },
+
+  clear(): void {
+    registry.clear();
+  },
+};

--- a/src/hooks/useGeometrySelection.ts
+++ b/src/hooks/useGeometrySelection.ts
@@ -2,6 +2,7 @@ import { useCallback, useMemo } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import * as THREE from "three";
 import type { RootState } from "@/store";
+import { meshRegistry } from "@/helpers/meshRegistry";
 import {
   selectGeometry as selectGeometryAction,
   clearSelection as clearSelectionAction,
@@ -16,19 +17,71 @@ import {
   removeSelectedGeometries as removeSelectedGeometriesAction,
   clearSelectedGeometries as clearSelectedGeometriesAction,
 } from "@/store/geometrySelectionSlice";
-import type { SelectedGeometry } from "@/store/geometrySelectionSlice";
+import type { SelectedGeometry, SerializableGeometry } from "@/store/geometrySelectionSlice";
+
+// Convert a mesh-based geometry (from a component) into the serializable form
+// stored in Redux, registering the live mesh instance so it can be resolved
+// again on read.
+function toSerializable(geometry: SelectedGeometry): SerializableGeometry {
+  meshRegistry.register(geometry.mesh);
+  return {
+    meshUuid: geometry.mesh.uuid,
+    faceIndex: geometry.faceIndex,
+    point: { x: geometry.point.x, y: geometry.point.y, z: geometry.point.z },
+    materialId: geometry.materialId,
+  };
+}
+
+// Resolve a serializable geometry back into a mesh-based one via the registry.
+// Returns null if the mesh is no longer registered (e.g. after a model reload).
+function fromSerializable(geometry: SerializableGeometry | null): SelectedGeometry | null {
+  if (!geometry) return null;
+  const mesh = meshRegistry.get(geometry.meshUuid);
+  if (!mesh) return null;
+  return {
+    mesh,
+    faceIndex: geometry.faceIndex,
+    point: new THREE.Vector3(geometry.point.x, geometry.point.y, geometry.point.z),
+    materialId: geometry.materialId,
+  };
+}
 
 export function useGeometrySelection() {
   const dispatch = useDispatch();
-  const { selectedGeometry, highlightedMeshes, selectedGeometries } = useSelector(
-    (state: RootState) => state.geometrySelection,
+  const {
+    selectedGeometry: rawSelectedGeometry,
+    highlightedMeshUuids,
+    selectedGeometries: rawSelectedGeometries,
+  } = useSelector((state: RootState) => state.geometrySelection);
+
+  // Reconstruct mesh-based views from the serializable Redux state. Memoized on
+  // the raw state so identity only changes when the selection actually changes.
+  const selectedGeometry = useMemo(
+    () => fromSerializable(rawSelectedGeometry),
+    [rawSelectedGeometry],
   );
 
-  const highlightedMeshesSet = useMemo(() => new Set(highlightedMeshes), [highlightedMeshes]);
+  const highlightedMeshesSet = useMemo(() => {
+    const set = new Set<THREE.Mesh>();
+    highlightedMeshUuids.forEach((uuid) => {
+      const mesh = meshRegistry.get(uuid);
+      if (mesh) set.add(mesh);
+    });
+    return set;
+  }, [highlightedMeshUuids]);
+
+  const selectedGeometries = useMemo(() => {
+    const result: Record<string, SelectedGeometry> = {};
+    Object.values(rawSelectedGeometries).forEach((geometry) => {
+      const resolved = fromSerializable(geometry);
+      if (resolved) result[geometry.meshUuid] = resolved;
+    });
+    return result;
+  }, [rawSelectedGeometries]);
 
   const selectGeometry = useCallback(
     (geometry: SelectedGeometry | null) => {
-      dispatch(selectGeometryAction(geometry));
+      dispatch(selectGeometryAction(geometry ? toSerializable(geometry) : null));
     },
     [dispatch],
   );
@@ -39,21 +92,23 @@ export function useGeometrySelection() {
 
   const addHighlightedMesh = useCallback(
     (mesh: THREE.Mesh) => {
-      dispatch(addHighlightedMeshAction(mesh));
+      meshRegistry.register(mesh);
+      dispatch(addHighlightedMeshAction(mesh.uuid));
     },
     [dispatch],
   );
 
   const removeHighlightedMesh = useCallback(
     (mesh: THREE.Mesh) => {
-      dispatch(removeHighlightedMeshAction(mesh));
+      dispatch(removeHighlightedMeshAction(mesh.uuid));
     },
     [dispatch],
   );
 
   const addHighlightedMeshes = useCallback(
     (meshes: THREE.Mesh[]) => {
-      dispatch(addHighlightedMeshesAction(meshes));
+      meshRegistry.registerMany(meshes);
+      dispatch(addHighlightedMeshesAction(meshes.map((mesh) => mesh.uuid)));
     },
     [dispatch],
   );
@@ -71,21 +126,21 @@ export function useGeometrySelection() {
 
   const addSelectedGeometry = useCallback(
     (geometry: SelectedGeometry) => {
-      dispatch(addSelectedGeometryAction(geometry));
+      dispatch(addSelectedGeometryAction(toSerializable(geometry)));
     },
     [dispatch],
   );
 
   const addSelectedGeometries = useCallback(
     (geometries: SelectedGeometry[]) => {
-      dispatch(addSelectedGeometriesAction(geometries));
+      dispatch(addSelectedGeometriesAction(geometries.map(toSerializable)));
     },
     [dispatch],
   );
 
   const removeSelectedGeometry = useCallback(
-    (materialId: string) => {
-      dispatch(removeSelectedGeometryAction(materialId));
+    (meshUuid: string) => {
+      dispatch(removeSelectedGeometryAction(meshUuid));
     },
     [dispatch],
   );

--- a/src/hooks/useGeometrySelection.ts
+++ b/src/hooks/useGeometrySelection.ts
@@ -6,10 +6,14 @@ import {
   selectGeometry as selectGeometryAction,
   clearSelection as clearSelectionAction,
   addHighlightedMesh as addHighlightedMeshAction,
+  addHighlightedMeshes as addHighlightedMeshesAction,
   removeHighlightedMesh as removeHighlightedMeshAction,
+  removeHighlightedMeshes as removeHighlightedMeshesAction,
   clearHighlights as clearHighlightsAction,
   addSelectedGeometry as addSelectedGeometryAction,
+  addSelectedGeometries as addSelectedGeometriesAction,
   removeSelectedGeometry as removeSelectedGeometryAction,
+  removeSelectedGeometries as removeSelectedGeometriesAction,
   clearSelectedGeometries as clearSelectedGeometriesAction,
 } from "@/store/geometrySelectionSlice";
 import type { SelectedGeometry } from "@/store/geometrySelectionSlice";
@@ -47,6 +51,20 @@ export function useGeometrySelection() {
     [dispatch],
   );
 
+  const addHighlightedMeshes = useCallback(
+    (meshes: THREE.Mesh[]) => {
+      dispatch(addHighlightedMeshesAction(meshes));
+    },
+    [dispatch],
+  );
+
+  const removeHighlightedMeshes = useCallback(
+    (meshUuids: string[]) => {
+      dispatch(removeHighlightedMeshesAction(meshUuids));
+    },
+    [dispatch],
+  );
+
   const clearHighlights = useCallback(() => {
     dispatch(clearHighlightsAction());
   }, [dispatch]);
@@ -58,9 +76,23 @@ export function useGeometrySelection() {
     [dispatch],
   );
 
+  const addSelectedGeometries = useCallback(
+    (geometries: SelectedGeometry[]) => {
+      dispatch(addSelectedGeometriesAction(geometries));
+    },
+    [dispatch],
+  );
+
   const removeSelectedGeometry = useCallback(
     (materialId: string) => {
       dispatch(removeSelectedGeometryAction(materialId));
+    },
+    [dispatch],
+  );
+
+  const removeSelectedGeometries = useCallback(
+    (meshUuids: string[]) => {
+      dispatch(removeSelectedGeometriesAction(meshUuids));
     },
     [dispatch],
   );
@@ -75,10 +107,14 @@ export function useGeometrySelection() {
     selectGeometry,
     clearSelection,
     addHighlightedMesh,
+    addHighlightedMeshes,
     removeHighlightedMesh,
+    removeHighlightedMeshes,
     clearHighlights,
     addSelectedGeometry,
+    addSelectedGeometries,
     removeSelectedGeometry,
+    removeSelectedGeometries,
     selectedGeometries,
     clearSelectedGeometries,
   };

--- a/src/store/geometrySelectionSlice.ts
+++ b/src/store/geometrySelectionSlice.ts
@@ -42,9 +42,26 @@ export const geometrySelectionSlice = createSlice({
       }
     },
 
+    addHighlightedMeshes: (state, action: PayloadAction<THREE.Mesh[]>) => {
+      const existingUuids = new Set(state.highlightedMeshes.map((m) => m.uuid));
+      action.payload.forEach((mesh) => {
+        if (!existingUuids.has(mesh.uuid)) {
+          existingUuids.add(mesh.uuid);
+          state.highlightedMeshes.push(mesh);
+        }
+      });
+    },
+
     removeHighlightedMesh: (state, action: PayloadAction<THREE.Mesh>) => {
       const meshUuid = action.payload.uuid;
       state.highlightedMeshes = state.highlightedMeshes.filter((mesh) => mesh.uuid !== meshUuid);
+    },
+
+    removeHighlightedMeshes: (state, action: PayloadAction<string[]>) => {
+      const uuidsToRemove = new Set(action.payload);
+      state.highlightedMeshes = state.highlightedMeshes.filter(
+        (mesh) => !uuidsToRemove.has(mesh.uuid),
+      );
     },
 
     addSelectedGeometry: (state, action: PayloadAction<SelectedGeometry>) => {
@@ -54,9 +71,23 @@ export const geometrySelectionSlice = createSlice({
       }
     },
 
+    addSelectedGeometries: (state, action: PayloadAction<SelectedGeometry[]>) => {
+      action.payload.forEach((geometry) => {
+        if (geometry.materialId) {
+          state.selectedGeometries[geometry.mesh.uuid] = geometry;
+        }
+      });
+    },
+
     removeSelectedGeometry: (state, action: PayloadAction<string>) => {
       const meshUuid = action.payload;
       delete state.selectedGeometries[meshUuid];
+    },
+
+    removeSelectedGeometries: (state, action: PayloadAction<string[]>) => {
+      action.payload.forEach((meshUuid) => {
+        delete state.selectedGeometries[meshUuid];
+      });
     },
 
     clearSelectedGeometries: (state) => {
@@ -73,10 +104,14 @@ export const {
   selectGeometry,
   clearSelection,
   addHighlightedMesh,
+  addHighlightedMeshes,
   removeHighlightedMesh,
+  removeHighlightedMeshes,
   clearHighlights,
   addSelectedGeometry,
+  addSelectedGeometries,
   removeSelectedGeometry,
+  removeSelectedGeometries,
   clearSelectedGeometries,
 } = geometrySelectionSlice.actions;
 

--- a/src/store/geometrySelectionSlice.ts
+++ b/src/store/geometrySelectionSlice.ts
@@ -1,7 +1,12 @@
 import { createSlice } from "@reduxjs/toolkit";
 import type { PayloadAction } from "@reduxjs/toolkit";
-import * as THREE from "three";
+import type * as THREE from "three";
 
+/**
+ * Public, mesh-based geometry shape used by components and the
+ * `useGeometrySelection` hook API. Meshes are resolved from the mesh registry;
+ * they are never stored in Redux.
+ */
 export interface SelectedGeometry {
   mesh: THREE.Mesh;
   faceIndex: number;
@@ -9,15 +14,23 @@ export interface SelectedGeometry {
   materialId?: string;
 }
 
+/** Serializable form actually stored in Redux state. */
+export interface SerializableGeometry {
+  meshUuid: string;
+  faceIndex: number;
+  point: { x: number; y: number; z: number };
+  materialId?: string;
+}
+
 interface GeometrySelectionState {
-  selectedGeometry: SelectedGeometry | null;
-  highlightedMeshes: THREE.Mesh[];
-  selectedGeometries: Record<string, SelectedGeometry>;
+  selectedGeometry: SerializableGeometry | null;
+  highlightedMeshUuids: string[];
+  selectedGeometries: Record<string, SerializableGeometry>;
 }
 
 const initialState: GeometrySelectionState = {
   selectedGeometry: null,
-  highlightedMeshes: [],
+  highlightedMeshUuids: [],
   selectedGeometries: {},
 };
 
@@ -25,7 +38,7 @@ export const geometrySelectionSlice = createSlice({
   name: "geometrySelection",
   initialState,
   reducers: {
-    selectGeometry: (state, action: PayloadAction<SelectedGeometry | null>) => {
+    selectGeometry: (state, action: PayloadAction<SerializableGeometry | null>) => {
       state.selectedGeometry = action.payload;
     },
 
@@ -34,47 +47,46 @@ export const geometrySelectionSlice = createSlice({
       state.selectedGeometries = {};
     },
 
-    addHighlightedMesh: (state, action: PayloadAction<THREE.Mesh>) => {
-      const mesh = action.payload;
-      const exists = state.highlightedMeshes.find((m) => m.uuid === mesh.uuid);
-      if (!exists) {
-        state.highlightedMeshes.push(mesh);
+    addHighlightedMesh: (state, action: PayloadAction<string>) => {
+      const uuid = action.payload;
+      if (!state.highlightedMeshUuids.includes(uuid)) {
+        state.highlightedMeshUuids.push(uuid);
       }
     },
 
-    addHighlightedMeshes: (state, action: PayloadAction<THREE.Mesh[]>) => {
-      const existingUuids = new Set(state.highlightedMeshes.map((m) => m.uuid));
-      action.payload.forEach((mesh) => {
-        if (!existingUuids.has(mesh.uuid)) {
-          existingUuids.add(mesh.uuid);
-          state.highlightedMeshes.push(mesh);
+    addHighlightedMeshes: (state, action: PayloadAction<string[]>) => {
+      const existing = new Set(state.highlightedMeshUuids);
+      action.payload.forEach((uuid) => {
+        if (!existing.has(uuid)) {
+          existing.add(uuid);
+          state.highlightedMeshUuids.push(uuid);
         }
       });
     },
 
-    removeHighlightedMesh: (state, action: PayloadAction<THREE.Mesh>) => {
-      const meshUuid = action.payload.uuid;
-      state.highlightedMeshes = state.highlightedMeshes.filter((mesh) => mesh.uuid !== meshUuid);
+    removeHighlightedMesh: (state, action: PayloadAction<string>) => {
+      const uuid = action.payload;
+      state.highlightedMeshUuids = state.highlightedMeshUuids.filter((id) => id !== uuid);
     },
 
     removeHighlightedMeshes: (state, action: PayloadAction<string[]>) => {
       const uuidsToRemove = new Set(action.payload);
-      state.highlightedMeshes = state.highlightedMeshes.filter(
-        (mesh) => !uuidsToRemove.has(mesh.uuid),
+      state.highlightedMeshUuids = state.highlightedMeshUuids.filter(
+        (uuid) => !uuidsToRemove.has(uuid),
       );
     },
 
-    addSelectedGeometry: (state, action: PayloadAction<SelectedGeometry>) => {
+    addSelectedGeometry: (state, action: PayloadAction<SerializableGeometry>) => {
       const geometry = action.payload;
       if (geometry.materialId) {
-        state.selectedGeometries[geometry.mesh.uuid] = geometry;
+        state.selectedGeometries[geometry.meshUuid] = geometry;
       }
     },
 
-    addSelectedGeometries: (state, action: PayloadAction<SelectedGeometry[]>) => {
+    addSelectedGeometries: (state, action: PayloadAction<SerializableGeometry[]>) => {
       action.payload.forEach((geometry) => {
         if (geometry.materialId) {
-          state.selectedGeometries[geometry.mesh.uuid] = geometry;
+          state.selectedGeometries[geometry.meshUuid] = geometry;
         }
       });
     },
@@ -95,7 +107,7 @@ export const geometrySelectionSlice = createSlice({
     },
 
     clearHighlights: (state) => {
-      state.highlightedMeshes = [];
+      state.highlightedMeshUuids = [];
     },
   },
 });

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -40,19 +40,8 @@ export const store = configureStore({
   middleware: (getDefaultMiddleware) =>
     getDefaultMiddleware({
       serializableCheck: {
-        ignoredActions: [
-          "model/storeRhinoFile",
-          "geometrySelection/selectGeometry",
-          "geometrySelection/addHighlightedMesh",
-          "geometrySelection/removeHighlightedMesh",
-          "auralizationApi/executeQuery/fulfilled",
-        ],
-        ignoredPaths: [
-          "model.rhinoFiles",
-          "geometrySelection.selectedGeometry",
-          "geometrySelection.highlightedMeshes",
-          auralizationApi.reducerPath,
-        ],
+        ignoredActions: ["model/storeRhinoFile", "auralizationApi/executeQuery/fulfilled"],
+        ignoredPaths: ["model.rhinoFiles", auralizationApi.reducerPath],
       },
     }).concat(
       projectApi.middleware,

--- a/src/store/materialAssignmentSlice.ts
+++ b/src/store/materialAssignmentSlice.ts
@@ -18,9 +18,22 @@ export const materialAssignmentSlice = createSlice({
       state.assignments[meshId] = materialId;
     },
 
+    assignMaterials: (state, action: PayloadAction<{ meshIds: string[]; materialId: number }>) => {
+      const { meshIds, materialId } = action.payload;
+      meshIds.forEach((meshId) => {
+        state.assignments[meshId] = materialId;
+      });
+    },
+
     removeMaterialAssignment: (state, action: PayloadAction<string>) => {
       const meshId = action.payload;
       delete state.assignments[meshId];
+    },
+
+    removeMaterialAssignments: (state, action: PayloadAction<string[]>) => {
+      action.payload.forEach((meshId) => {
+        delete state.assignments[meshId];
+      });
     },
 
     clearAllAssignments: (state) => {
@@ -33,7 +46,13 @@ export const materialAssignmentSlice = createSlice({
   },
 });
 
-export const { assignMaterial, removeMaterialAssignment, clearAllAssignments, setAssignments } =
-  materialAssignmentSlice.actions;
+export const {
+  assignMaterial,
+  assignMaterials,
+  removeMaterialAssignment,
+  removeMaterialAssignments,
+  clearAllAssignments,
+  setAssignments,
+} = materialAssignmentSlice.actions;
 
 export default materialAssignmentSlice.reducer;


### PR DESCRIPTION
@SilvinWillemsen  @mberz 
This feature groups surfaces based on the materials specified in the .obj input (usemtl). Users can also assign surface materials by group.

### Improvements
- Assign material per group
- Implement https://tanstack.com/virtual/latest so that the group surfaces only render the list that user see.
- Refactored the surface highlighting state management to use batched updates. Previously, each highlighted surface triggered an individual state update, resulting in repeated updates for large models. This reduces unnecessary state updates and improves performance when working with models containing many surfaces.
- Made the geometry-selection Redux state fully serializable. Previously the store held live Three.js objects (THREE.Mesh and THREE.Vector3) directly, which is non-serializable and required disabling Redux's serializability checks for those slices. The state now stores only serializable data (mesh UUIDs and plain {x, y, z} points), while the live meshes are kept in a separate module-level meshRegistry and resolved back by UUID when needed. This restores Redux's serializability guarantees (safe for DevTools, persistence, and time-travel), shrinks the store, and makes selection updates cheaper to diff.
